### PR TITLE
Node Group Regex

### DIFF
--- a/lib/puppet/type/node_group.rb
+++ b/lib/puppet/type/node_group.rb
@@ -35,7 +35,7 @@ Puppet::Type.newtype(:node_group) do
     desc 'Environment for this group'
     defaultto :production
     validate do |value|
-      fail("Invalid environment name") unless value =~ /^[a-z][a-z0-9]+$/
+      fail("Invalid environment name") unless value =~ /^[a-z][a-z0-9_]+$/
     end
   end
   newproperty(:classes) do


### PR DESCRIPTION
This fix changes the regex check for the `environment` name for Node
Groups to that which is specified in
https://docs.puppetlabs.com/puppet/latest/reference/lang_reserved.html#environments
