### PR TITLE
Do not require 'puppetclassify' to compile

### DIFF
--- a/lib/puppet/parser/functions/node_groups.rb
+++ b/lib/puppet/parser/functions/node_groups.rb
@@ -9,7 +9,7 @@ module Puppet::Parser::Functions
     )
 
     ng     = Puppet::Util::Node_groups.new
-    groups = ng.groups
+    groups = ng.groups.get_groups
 
     # When querying a specific group
     if args.length == 1

--- a/lib/puppet/parser/functions/node_groups.rb
+++ b/lib/puppet/parser/functions/node_groups.rb
@@ -1,0 +1,24 @@
+require 'puppet/util/node_groups'
+
+module Puppet::Parser::Functions
+  newfunction(:node_groups, :type => :rvalue) do |args|
+    node_name = args[0]
+    raise ArgumentError, 'Function accepts a single String' unless (
+      args.length == 0 or
+      ( args.length == 1 and node_name.is_a?(String) )
+    )
+
+    ng     = Puppet::Util::Node_groups.new
+    groups = ng.groups
+
+    # When querying a specific group
+    if args.length == 1
+      # Assuming there is only one group by the name
+      Puppet::Util::Node_groups.hashify_group_array(
+        groups.select { |g| g['name'] == node_name }
+      )
+    else
+      Puppet::Util::Node_groups.hashify_group_array(groups)
+    end
+  end
+end

--- a/lib/puppet/provider/node_group/puppetclassify.rb
+++ b/lib/puppet/provider/node_group/puppetclassify.rb
@@ -1,3 +1,4 @@
+require 'puppet/util/node_groups'
 require 'yaml'
 
 Puppet::Type.type(:node_group).provide(:puppetclassify) do
@@ -17,21 +18,7 @@ Puppet::Type.type(:node_group).provide(:puppetclassify) do
   end
 
   def self.initialize_client
-    auth_info = {
-      "ca_certificate_path" => Puppet.settings['localcacert'],
-      "certificate_path"    => Puppet.settings['hostcert'],
-      "private_key_path"    => Puppet.settings['hostprivkey'],
-    }
-
-    begin
-      nc_settings = YAML.load_file("#{Puppet.settings['confdir']}/classifier.yaml")
-    rescue
-      fail "Could not find file #{Puppet.settings['confdir']}/classifier.yaml"
-    else
-      classifier_url = "https://#{nc_settings['server']}:#{nc_settings['port']}/classifier-api"
-    end
-
-    PuppetClassify.new(classifier_url, auth_info)
+    Puppet::Util::Node_groups.new
   end
 
   # API will fail if disallowed-keys are passed

--- a/lib/puppet/type/puppet_environment.rb
+++ b/lib/puppet/type/puppet_environment.rb
@@ -4,7 +4,7 @@ Puppet::Type.newtype(:puppet_environment) do
   newparam(:name, :namevar => true) do
     desc 'This is the name of the environment'
     validate do |value|
-      fail("#{value} is not a valid group name") unless value =~ /\A[a-z0-9_]+\Z/
+      fail("#{value} is not a valid group name") unless value =~ /\A[a-z0-9_]+\Z/ or value == 'agent-specified'
     end
   end
 end

--- a/lib/puppet/type/puppet_environment.rb
+++ b/lib/puppet/type/puppet_environment.rb
@@ -4,7 +4,7 @@ Puppet::Type.newtype(:puppet_environment) do
   newparam(:name, :namevar => true) do
     desc 'This is the name of the environment'
     validate do |value|
-      fail("#{value} is not a valid group name") unless value =~ /\A[a-z0-9_]+\Z/ or value == 'agent-specified'
+      fail("#{value} is not a valid environment name") unless value =~ /\A[a-z0-9_]+\Z/ or value == 'agent-specified'
     end
   end
 end

--- a/lib/puppet/util/node_groups.rb
+++ b/lib/puppet/util/node_groups.rb
@@ -1,8 +1,9 @@
 require 'puppetclassify'
 require 'yaml'
 
-class Puppet::Util::Node_groups
+class Puppet::Util::Node_groups < PuppetClassify
   attr_reader :groups
+  alias_method :groups, :groups
 
   def initialize
     auth_info = {
@@ -20,7 +21,7 @@ class Puppet::Util::Node_groups
     end
 
     ng      = PuppetClassify.new(classifier_url, auth_info)
-    @groups = ng.groups.get_groups
+    @groups = ng.groups
   end
 
   # Transform the node group array in to a hash

--- a/lib/puppet/util/node_groups.rb
+++ b/lib/puppet/util/node_groups.rb
@@ -1,0 +1,38 @@
+require 'puppetclassify'
+require 'yaml'
+
+class Puppet::Util::Node_groups
+  attr_reader :groups
+
+  def initialize
+    auth_info = {
+      "ca_certificate_path" => Puppet.settings['localcacert'],
+      "certificate_path"    => Puppet.settings['hostcert'],
+      "private_key_path"    => Puppet.settings['hostprivkey'],
+    }
+
+    begin
+      nc_settings = YAML.load_file("#{Puppet.settings['confdir']}/classifier.yaml")
+    rescue
+      fail "Could not find file #{Puppet.settings['confdir']}/classifier.yaml"
+    else
+      classifier_url = "https://#{nc_settings['server']}:#{nc_settings['port']}/classifier-api"
+    end
+
+    ng      = PuppetClassify.new(classifier_url, auth_info)
+    @groups = ng.groups.get_groups
+  end
+
+  # Transform the node group array in to a hash
+  # with a key of the name and an attribute
+  # hash of the rest.
+  def self.hashify_group_array(group_array)
+    hashified = Hash.new
+
+    group_array.each do |group|
+      hashified[group['name']] = group
+    end
+
+    hashified
+  end
+end

--- a/lib/puppet/util/node_groups.rb
+++ b/lib/puppet/util/node_groups.rb
@@ -1,7 +1,17 @@
-require 'puppetclassify'
-require 'yaml'
+# The provider is loaded both by the master and by the agent. Only the agent
+# will actually need the puppetclassify gem and methods. In order to allow
+# seamless loading by the masteror during compilation prior to enforcing state,
+# allow graceful failure when unable to load puppetclassify.
 
-class Puppet::Util::Node_groups < PuppetClassify
+begin
+  require 'yaml'
+  require 'puppetclassify'
+  parent = PuppetClassify
+rescue LoadError => e
+  parent = Object
+end
+
+class Puppet::Util::Node_groups < parent
   attr_reader :groups
   alias_method :groups, :groups
 

--- a/spec/unit/puppet/type/node_group_spec.rb
+++ b/spec/unit/puppet/type/node_group_spec.rb
@@ -38,6 +38,15 @@ describe Puppet::Type.type(:node_group) do
     }.to_not raise_error
   end
 
+  it "should allow environment name 'agent-specified'" do
+    expect {
+      Puppet::Type.type(:node_group).new(
+        :name        => 'stubname',
+        :environment => 'agent-specified',
+      )
+    }.to_not raise_error
+  end
+
   it "should not allow environment name with a dash" do
     expect {
       Puppet::Type.type(:node_group).new(

--- a/spec/unit/puppet/type/puppet_environment_spec.rb
+++ b/spec/unit/puppet/type/puppet_environment_spec.rb
@@ -26,6 +26,14 @@ describe Puppet::Type.type(:puppet_environment) do
     }.to_not raise_error
   end
 
+  it "should allow 'agent-specified' environment" do
+    expect {
+      Puppet::Type.type(:puppet_environment).new(
+        :name => 'agent-specified',
+      )
+    }.to_not raise_error
+  end
+
   it "should not allow environment name with a dash" do
     expect {
       Puppet::Type.type(:puppet_environment).new(


### PR DESCRIPTION
There is no functional requirement for the puppetclassify gem to be
installed in order to compile a catalog that includes node_group types.
This commit modifies the code such that the compilation process will not
fail if puppetclassify is not yet installed. This enables the bootstrap
use case, where the master can in a single Puppet run install the
puppetclassify gem on itself and then use it to configure the
classifier.
