### PR TITLE
Fix markdown rendering issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # node_manager [![Build Status](https://travis-ci.org/WhatsARanjit/prosvcs-node_manager.svg)](https://travis-ci.org/WhatsARanjit/prosvcs-node_manager)
 
 #### Table of Contents
+
 1. [Overview](#overview)
 1. [Requirements](#requirements)
 1. [Types](#types)
@@ -16,19 +17,21 @@ Create and manage Node Manager API endpoints as resources.
 
 ## Module State
 
-NOTE: This module is a Professional Service side project and is currently unmaintained. 
+NOTE: This module is a Professional Service side project and is currently unmaintained.
 It is not supported and may not function as expected.
 
-## Requirements:
+## Requirements
 
-- *nix operating system
-- Puppet >= 3.7.1  
-- [puppetclassify](https://github.com/puppetlabs/puppet-classify) gem
-- [puppetlabs/pe_gem module](https://forge.puppetlabs.com/puppetlabs/pe_gem)
-- NOTE: new `https` provider which doesn't need gem dependency at [HTTPS.md](HTTPS.md)
+* \*nix operating system
+* Puppet >= 3.7.1
+* [puppetclassify](https://github.com/puppetlabs/puppet-classify) gem
+* [puppetlabs/pe_gem module](https://forge.puppetlabs.com/puppetlabs/pe_gem)
+* NOTE: new `https` provider which doesn't need gem dependency at [HTTPS.md](HTTPS.md)
 
 ## Classes
+
 ### Node_manager
+
 The node_manager class facilitates the deployment of the puppetclassify gem
 simply include node_manager in your node definition or add it to the pe_master node group
 
@@ -39,10 +42,12 @@ simply include node_manager in your node definition or add it to the pe_master n
 Node_groups will autorequire parent node_groups.
 
 Enumerate all node groups:
-* `puppet resource node_group`<br />
+
+* `puppet resource node_group`
 
 Example output for `puppet resource node_group 'PE MCollective'`
-```
+
+```puppet
 node_group { 'PE MCollective':
   ensure               => 'present',
   classes              => {'puppet_enterprise::profile::mcollective::agent' => {}},
@@ -56,45 +61,63 @@ node_group { 'PE MCollective':
 
 #### Node_group parameters
 
-* `classes`<br />
-Classes that are assigned to the node in hash format.  Elements of the hash
-are class parameters. Default (empty hash): `{}`
+* `classes`
 
-* `environment`<br />
-Environment selected for this node group. Default: `production`
+  Classes that are assigned to the node in hash format. Elements of the hash are class parameters.
 
-* `name`<br />
-(namevar) Node group's name.
+  Default (empty hash): `{}`
 
-* `id`<br />
-Universal ID for the group. This attribute is read-only.
+* `environment`
 
-* `override_environment`<br />
-Whether or not this group's environment ment setting overrides
-all other other environments. Default: `false`
+  Environment selected for this node group.
 
-* `parent`<br />
-The UID for the data group. Can be specified by group name or
-UID. Default: `default`
+  Default: `production`
 
-* `rules`<br />
-An array of classification rules. Default (empty array): `[]`
+* `name`
+
+  (namevar) Node group's name.
+
+* `id`
+
+  Universal ID for the group. This attribute is read-only.
+
+* `override_environment`
+
+  Whether or not this group's environment ment setting overrides all other other environments.
+
+  Default: `false`
+
+* `parent`
+
+  The UID for the data group. Can be specified by group name or UID.
+
+  Default: `default`
+
+* `rules`
+
+  An array of classification rules.
+
+  Default (empty array): `[]`
 
 ### Puppet_environment
 
 Enumerate all puppet environments:
-* `puppet resource puppet_environment`<br />
+
+* `puppet resource puppet_environment`
 
 Example output for `puppet resource puppet_environment production`
-```
+
+```puppet
 puppet_environment { 'production':
   ensure => 'present',
 }
 ```
+
 #### Puppet_environment parameters
 
-* `name`<br />
-(namevar) Name of the Puppet environment on disk, i.e. the directory name in `$environmentpath`.
+* `name`
+
+  (namevar) Name of the Puppet environment on disk, i.e. the directory name in `$environmentpath`.
 
 ## Functions
 
@@ -104,7 +127,7 @@ Retrieve all or one node_group and its data.
 
 `node_groups()` will return:
 
-```
+```puppet
 {
   "default"=>{
     "environment_trumps"=>false,
@@ -131,7 +154,7 @@ Retrieve all or one node_group and its data.
 
 `node_groups('default')` will return:
 
-```
+```puppet
 {
   "default"=>{
     "environment_trumps"=>false,
@@ -148,11 +171,14 @@ Retrieve all or one node_group and its data.
 _Type:_ rvalue
 
 ## Things to do
-  - Remove `puppetclassify` dependency
-  - Get feedback on `https` provider, new [HTTPS.md](HTTPS.md)
+
+* Remove `puppetclassify` dependency
+* Get feedback on `https` provider, new [HTTPS.md](HTTPS.md)
 
 ## Maintainers
+
 This repositority is largely the work of some Puppet community members.
 It is not officially maintained by Puppet, or any individual in
-particular.  Issues should be opened in Github.  Questions should be directed
+particular. Issues should be opened in Github. Questions should be directed
 at the individuals responsible for committing that particular code.
+


### PR DESCRIPTION
Prior to this there were a few issues with how the README was rendered
on GitHub and the Forge. This commit fixes the following:

* Code block syntax highlighting
* list indentation
* Other minor markdown syntax fixes