### PR TITLE
Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ node_group { 'PE MCollective':
 
 #### Node_group parameters
 
+* `description`<br />
+Description of the node_group.
+
 * `classes`<br />
 Classes that are assigned to the node in hash format.  Elements of the hash
 are class parameters. Default (empty hash): `{}`

--- a/lib/puppet/provider/node_group/https.rb
+++ b/lib/puppet/provider/node_group/https.rb
@@ -30,7 +30,8 @@ Puppet::Type.type(:node_group).provide(:https) do
       :name               => 'name',
       :parent             => 'parent',
       :rule               => 'rule',
-      :variables          => 'variables'
+      :variables          => 'variables',
+      :description        => 'description',
     }
   end
 

--- a/lib/puppet/provider/node_group/puppetclassify.rb
+++ b/lib/puppet/provider/node_group/puppetclassify.rb
@@ -31,12 +31,12 @@ Puppet::Type.type(:node_group).provide(:puppetclassify) do
       :name               => 'name',
       :parent             => 'parent',
       :rule               => 'rule',
-      :variables          => 'variables'
+      :variables          => 'variables',
+      :description        => 'description',
     }
   end
 
   def self.instances
-    deprecation_warning('This provider is being deprecated.  See https provider at https://github.com/WhatsARanjit/prosvcs-node_manager/blob/https_provider/HTTPS.md')
     $ngs = classifier.groups.get_groups
     $ngs.collect do |group|
       ngs_hash = {}
@@ -57,6 +57,7 @@ Puppet::Type.type(:node_group).provide(:puppetclassify) do
   end
 
   def self.prefetch(resources)
+    deprecation_warning('This provider is being deprecated.  See https provider at https://github.com/WhatsARanjit/prosvcs-node_manager/blob/https_provider/HTTPS.md')
     ngs = instances
     resources.keys.each do |group|
       if provider = ngs.find{ |g| g.name == group }

--- a/lib/puppet/type/node_group.rb
+++ b/lib/puppet/type/node_group.rb
@@ -40,6 +40,9 @@ Puppet::Type.newtype(:node_group) do
       fail("Classes must be supplied as a hash") unless value.is_a?(Hash)
     end
   end
+  newproperty(:description) do
+    desc 'Description of this group'
+  end
 
   autorequire(:node_group) do
     self[:parent] if @parameters.include? :parent

--- a/spec/integration/puppet/provider/node_group/https_spec.rb
+++ b/spec/integration/puppet/provider/node_group/https_spec.rb
@@ -20,7 +20,8 @@ describe Puppet::Type.type(:node_group).provider(:https) do
                 ".*"
             ]
         ],
-        "variables": {}
+        "variables": {},
+        "description": "Sample message"
     }
   ]
   EOS
@@ -35,6 +36,7 @@ describe Puppet::Type.type(:node_group).provider(:https) do
       "stubkey"  => "stubvalue",
       "stubkey2" => "stubvalue2"
     },
+    "description"        => "Sample message",
     "name"               => "stub_name",
   }.to_json
 
@@ -51,6 +53,7 @@ describe Puppet::Type.type(:node_group).provider(:https) do
         :stubkey  => :stubvalue,
         :stubkey2 => :stubvalue2,
       },
+      :description          => "Sample message",
     )
   end
 

--- a/spec/integration/puppet/provider/node_group/puppetclassify_spec.rb
+++ b/spec/integration/puppet/provider/node_group/puppetclassify_spec.rb
@@ -20,7 +20,8 @@ describe Puppet::Type.type(:node_group).provider(:puppetclassify) do
                 ".*"
             ]
         ],
-        "variables": {}
+        "variables": {},
+        "description": "Sample message"
     }
   ]
   EOS
@@ -36,6 +37,7 @@ describe Puppet::Type.type(:node_group).provider(:puppetclassify) do
       "stubkey"  => "stubvalue",
       "stubkey2" => "stubvalue2"
     },
+    "description"        => "Sample message",
     "name"               => "stub_name",
   }.to_json
 
@@ -52,6 +54,7 @@ describe Puppet::Type.type(:node_group).provider(:puppetclassify) do
         :stubkey  => :stubvalue,
         :stubkey2 => :stubvalue2,
       },
+      :description          => "Sample message",
     )
   end
 

--- a/spec/unit/puppet/type/node_group_spec.rb
+++ b/spec/unit/puppet/type/node_group_spec.rb
@@ -64,4 +64,13 @@ describe Puppet::Type.type(:node_group) do
     }.to_not raise_error
   end
 
+  it "should accept a description parameter" do
+    expect {
+      Puppet::Type.type(:node_group).new(
+        :name        => 'stubname',
+        :description => 'Sample message',
+      )
+    }.to_not raise_error
+  end
+
 end


### PR DESCRIPTION
Added a `description` attribute to map to a node group's description in the API.  This was an ask from https://github.com/WhatsARanjit/prosvcs-node_manager/issues/10.  Updated `puppetclassify` and `https` provider for it and corresponding spec tests.  Moved deprecation warning for `puppetclassify` to `prefetch` so it wouldn't fire unless the provider was actually used.