### PR TITLE
Added logic for cancelling unwanted classes/variables for issue #11

### DIFF
--- a/lib/puppet/provider/node_group/https.rb
+++ b/lib/puppet/provider/node_group/https.rb
@@ -137,6 +137,11 @@ Puppet::Type.type(:node_group).provide(:https) do
           gindex = $ngs.index { |i| i['name'] == value }
           @property_flush['attrs'][property.to_s] = $ngs[gindex]['id']
         end
+      # These 2 attributes are additive, so need to submit nulls to remove unwanted values
+      elsif [:variables, :classes].include?(property)
+        @property_flush['attrs'][property.to_s] = add_nulls(@property_hash[property], value)
+        # For logging return to original intended value
+        @resource[property] = value.select { |k,v| v != nil }
       else
         # The to_json function needs to recognize
         # booleans true/false, not symbols :true/false
@@ -170,6 +175,13 @@ Puppet::Type.type(:node_group).provide(:https) do
 
   def get_id_index_from_name(name)
     $ngs.index { |i| i['name'] == name }
+  end
+
+  def add_nulls(current, new)
+    difference = current.keys - new.keys
+    nullhash   = new
+    difference.each { |k| nullhash[k] = nil }
+    nullhash
   end
 
 end

--- a/lib/puppet/provider/node_group/puppetclassify.rb
+++ b/lib/puppet/provider/node_group/puppetclassify.rb
@@ -148,6 +148,11 @@ Puppet::Type.type(:node_group).provide(:puppetclassify) do
           gindex = $ngs.index { |i| i['name'] == value }
           @property_flush['attrs'][property.to_s] = $ngs[gindex]['id']
         end
+      # These 2 attributes are additive, so need to submit nulls to remove unwanted values
+      elsif [:variables, :classes].include?(property)
+        @property_flush['attrs'][property.to_s] = add_nulls(@property_hash[property], value)
+        # For logging return to original intended value
+        @resource[property] = value.select { |k,v| v != nil }
       else
         # The to_json function needs to recognize
         # booleans true/false, not symbols :true/false
@@ -187,6 +192,13 @@ Puppet::Type.type(:node_group).provide(:puppetclassify) do
 
   def get_id_index_from_name(name)
     $ngs.index { |i| i['name'] == name }
+  end
+
+  def add_nulls(current, new)
+    difference = current.keys - new.keys
+    nullhash   = new
+    difference.each { |k| nullhash[k] = nil }
+    nullhash
   end
 
 end


### PR DESCRIPTION
The `classes` and `variables` attributes are additive.  Meaning if you have a current resource like:

```
node_group { 'test':
  classes   => { klass{} => {}},
  variables => { 'key' => 'value' },
}
```

...and we write a `node_group` definition like:

```
node_group { 'test':
  classes   => {},
  variables => {},
}
```

..the intended result is to remove all classes and variables.  However, the actual result is to append new items to existing items.  So:

```
{ klass{} => {}} + {}
{ 'key' => 'value' } + {}
```

...and so the result is nothing is actually changed.  In order to remove items, you actually have to submit:

```
{ klass{} => {}} + { klass => null }
{ 'key' => 'value' } + { 'key' => null }
```

Sending a `null` signals the API to remove the item.  This PR adds a `add_nulls()` method which diffs current-state/desired-state to add `null` values to things that should be removed.