### PR TITLE
Hash order

### DIFF
--- a/lib/puppet/parser/functions/node_groups.rb
+++ b/lib/puppet/parser/functions/node_groups.rb
@@ -1,8 +1,10 @@
 begin
   require 'puppet/util/nc_https'
+  require 'puppet_x/node_manager/common'
 rescue LoadError
   mod = Puppet::Module.find('node_manager', Puppet[:environment].to_s)
   require File.join mod.path, 'lib/puppet/util/nc_https'
+  require File.join mod.path, 'lib/puppet_x/node_manager/common'
 end
 
 module Puppet::Parser::Functions
@@ -19,11 +21,11 @@ module Puppet::Parser::Functions
     # When querying a specific group
     if args.length == 1
       # Assuming there is only one group by the name
-      Puppet::Util::Nc_https.hashify_group_array(
+      PuppetX::Node_manager::Common.hashify_group_array(
         groups.select { |g| g['name'] == node_name }
       )
     else
-      Puppet::Util::Nc_https.hashify_group_array(groups)
+      PuppetX::Node_manager::Common.hashify_group_array(groups)
     end
   end
 end

--- a/lib/puppet/provider/node_group/https.rb
+++ b/lib/puppet/provider/node_group/https.rb
@@ -1,4 +1,5 @@
 require 'puppet/util/nc_https'
+require 'puppet_x/node_manager/common'
 
 Puppet::Type.type(:node_group).provide(:https) do
 
@@ -126,6 +127,11 @@ Puppet::Type.type(:node_group).provide(:https) do
     else
       @property_hash[:parent]
     end
+  end
+
+  def classes
+    # Need to deep sort hashes so they be evaluated equally
+    PuppetX::Node_manager::Common.sort_hash(@property_hash[:classes])
   end
 
   friendly_name.each do |property,friendly|

--- a/lib/puppet/type/node_group.rb
+++ b/lib/puppet/type/node_group.rb
@@ -1,3 +1,5 @@
+require 'puppet_x/node_manager/common'
+
 Puppet::Type.newtype(:node_group) do
   desc 'The node_group type creates and manages node groups for the PE Node Manager'
   ensurable
@@ -38,6 +40,10 @@ Puppet::Type.newtype(:node_group) do
     defaultto {}
     validate do |value|
       fail("Classes must be supplied as a hash") unless value.is_a?(Hash)
+    end
+    # Need to deep sort hashes so they be evaluated equally
+    munge do |value|
+      PuppetX::Node_manager::Common.sort_hash(value)
     end
   end
   newproperty(:description) do

--- a/lib/puppet/util/nc_https.rb
+++ b/lib/puppet/util/nc_https.rb
@@ -64,19 +64,6 @@ class Puppet::Util::Nc_https
     end
   end
 
-  # Transform the node group array in to a hash
-  # with a key of the name and an attribute
-  # hash of the rest.
-  def self.hashify_group_array(group_array)
-    hashified = Hash.new
-
-    group_array.each do |group|
-      hashified[group['name']] = group
-    end
-
-    hashified
-  end
-
   private
 
   def do_https(endpoint, method = 'post', data = {})

--- a/lib/puppet/util/node_groups.rb
+++ b/lib/puppet/util/node_groups.rb
@@ -32,19 +32,6 @@ class Puppet::Util::Node_groups < parent
     super(classifier_url, auth_info)
   end
 
-  # Transform the node group array in to a hash
-  # with a key of the name and an attribute
-  # hash of the rest.
-  def self.hashify_group_array(group_array)
-    hashified = Hash.new
-
-    group_array.each do |group|
-      hashified[group['name']] = group
-    end
-
-    hashified
-  end
-
   # puppetclassify does not currently have a
   # method to delete environments.  Using this
   # in the meantime.

--- a/lib/puppet_x/node_manager/common.rb
+++ b/lib/puppet_x/node_manager/common.rb
@@ -16,10 +16,16 @@ module PuppetX::Node_manager::Common
   end
 
   def self.sort_hash(data)
-    newhash = data.sort.to_h if data.is_a?(Hash)
+    newhash = Hash.new
+    if data.is_a?(Hash)
+      # .to_h method doesn't exist until Ruby 2.1.x
+      data.sort.flatten(1).each_slice(2) { |a,b| newhash[a] = b }
+    end
     newhash.each do |k,v|
       if v.is_a?(Hash)
         newhash[k] = sort_hash(v)
+      else
+        newhash[k] = v
       end
     end
     newhash

--- a/lib/puppet_x/node_manager/common.rb
+++ b/lib/puppet_x/node_manager/common.rb
@@ -1,0 +1,27 @@
+module PuppetX; end
+module PuppetX::Node_manager; end
+
+module PuppetX::Node_manager::Common
+  # Transform the node group array in to a hash
+  # with a key of the name and an attribute
+  # hash of the rest.
+  def self.hashify_group_array(group_array)
+    hashified = Hash.new
+
+    group_array.each do |group|
+      hashified[group['name']] = group
+    end
+
+    hashified
+  end
+
+  def self.sort_hash(data)
+    newhash = data.sort.to_h if data.is_a?(Hash)
+    newhash.each do |k,v|
+      if v.is_a?(Hash)
+        newhash[k] = sort_hash(v)
+      end
+    end
+    newhash
+  end
+end


### PR DESCRIPTION
* Created `puppet_x` for `sort_hash` method
  * Type uses `sort_hash` on input
  * Provider uses `sort_hash` when reading classes
* Moved `hashify_group_array` method to `puppet_x`

As a note, I originally used the `.to_h` method in `sort_hash`.  The workflow was:
1. Convert hash into an array
1. Sort array
1. Convert back to hash with `to.h`

This failed on Travis with anything < Ruby 2.1.x.  Refactored to use `each_slice` and a lambda to be compatible across Ruby versions.