### PR TITLE
Initial commit on face

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     * [Puppet_environment](#puppet_environment)
 1. [Functions](#functions)
     * [node_groups()](#node_groups)
+1. [Face](#face)
 1. [Things to do](#things-to-do)
 
 ## Overview
@@ -196,6 +197,34 @@ Retrieve all or one node_group and its data.
   ```
 
 _Type:_ rvalue
+
+## Face
+
+The `node_manager` face allows you to interact with endpoints other than
+the groups endpoint using the type or function. Use the `--help` flag
+to explore functionaliy of each action.
+
+```
+# puppet node_manager --help
+
+USAGE: puppet node_manager <action>
+
+Interact with node classifier API
+
+OPTIONS:
+  --render-as FORMAT             - The rendering format to use.
+  --verbose                      - Whether to log verbosely.
+  --debug                        - Whether to log debug information.
+
+ACTIONS:
+  classes         List class information
+  classified      List classification information
+  environments    Query environment sync status
+  groups          List group information
+  unpin           Unpin a node from all groups
+
+See 'puppet man node_manager' or 'man puppet-node_manager' for full help.
+```
 
 ## Things to do
 

--- a/docs/face.md
+++ b/docs/face.md
@@ -1,0 +1,19 @@
+## `node_manager` face
+
+```
+USAGE: puppet node_manager <action>
+
+Interact with node classifier API
+
+OPTIONS:
+  --render-as FORMAT             - The rendering format to use.
+  --verbose                      - Whether to log verbosely.
+  --debug                        - Whether to log debug information.
+
+ACTIONS:
+  classes         List class information
+  classified      List classification information
+  environments    Query environment sync status
+  groups          List group information
+  unpin           Unpin a node from all groups
+```

--- a/lib/puppet/application/node_manager.rb
+++ b/lib/puppet/application/node_manager.rb
@@ -1,0 +1,5 @@
+require 'puppet/face'
+require 'puppet/application/face_base'
+
+class Puppet::Application::Node_manager < Puppet::Application::FaceBase
+end

--- a/lib/puppet/face/node_manager.rb
+++ b/lib/puppet/face/node_manager.rb
@@ -1,0 +1,225 @@
+require 'puppet'
+require 'puppet/face'
+require 'puppet/util/nc_https'
+require 'puppet_x/node_manager/common'
+
+Puppet::Face.define(:node_manager, '0.1.0') do
+  summary 'Interact with node classifier API'
+  copyright 'WhatsARanjit', 2017
+  license 'Apache-2.0'
+
+  classifier = Puppet::Util::Nc_https.new
+  output     = []
+
+  action :groups do
+    summary 'List group information'
+    arguments '[group_name]'
+
+    option '--export' do
+      summary 'Provide formatted JSON for import'
+      default_to { false }
+    end
+
+    option '--import JSONFILE' do
+      summary 'Import formatted JSON of groups'
+      default_to { false }
+    end
+
+    when_invoked do |*args|
+      options = args.last
+
+      if options[:import]
+        fail('Choose import or export') if options[:export]
+
+        'Success' if classifier.import_hierarchy(read_import(options[:import]))
+      else
+        groups  = classifier.get_groups
+
+        if args.length == 2
+          output << groups.select { |g| g['name'] == args.first }
+        elsif args.length == 1
+          output << groups
+        else
+          fail("wrong number of arguments (#{args.length-1} for 1)")
+        end
+        if options[:export]
+          output.flatten.to_json
+        else
+          PuppetX::Node_manager::Common.hashify_group_array(output.flatten)
+        end
+      end
+    end
+
+    when_rendering :console do |output|
+      case output
+      when Hash
+        if output.length == 0
+          fail('No groups found')
+        elsif output.length == 1
+          JSON.pretty_generate output.values[0]
+        else
+          output.keys
+        end
+      else
+        output
+      end
+    end
+  end
+
+  action :classes do
+    summary 'List class information'
+    arguments '[class]'
+
+    option '--update' do
+      summary 'Trigger classifier to update class list'
+      default_to { false }
+    end
+
+    when_invoked do |*args|
+      options    = args.last
+      klass      = args.first.is_a?(String) ? args.first : false
+      env        = options[:environment] ? options[:environment] : 'production'
+      queryenv   = options[:environment] ? options[:environment] : nil
+
+      if options[:update]
+        'Success' if classifier.update_classes(queryenv)
+      else
+        output << classifier.get_classes(env, klass)
+        PuppetX::Node_manager::Common.hashify_group_array(output.flatten)
+      end
+    end
+
+    when_rendering :console do |output|
+      case output
+      when Hash
+        if output.length <= 1
+          JSON.pretty_generate output.values[0]
+        else
+          output.keys
+        end
+      else
+        output
+      end
+    end
+  end
+
+  action :classified do
+    summary 'List classification information'
+    arguments 'nodename'
+
+    option '--explain' do
+      summary 'Provide explanation'
+      default_to { false }
+    end
+
+    option '--facts FACTSFILE' do
+      summary 'Provide facts YAML or JSON'
+      default_to { false }
+    end
+
+    option '--trusted TRUSTEDFILE' do
+      summary 'Provide trusted facts YAML or JSON'
+      default_to { false }
+    end
+
+    when_invoked do |nodename, options|
+      output << classifier.get_classified(
+        nodename,
+        options[:explain],
+        check_facts(options[:facts], options),
+        check_facts(options[:trusted], options),
+      )
+      output.flatten
+    end
+
+    when_rendering :console do |output, nodename, options|
+      if options[:explain] == true
+        JSON.pretty_generate output.first['match_explanations']
+      else
+        JSON.pretty_generate output.first['classes']
+      end
+    end
+  end
+
+  action :unpin do
+    summary 'Unpin a node from all groups'
+    arguments 'nodename'
+
+    when_invoked do |nodename, options|
+      output << classifier.unpin_from_all(nodename)
+      if output.flatten.first['nodes'].empty?
+        'Found nothing to unpin.'
+      else
+        PuppetX::Node_manager::Common.hashify_group_array(output.flatten['nodes'].first)
+      end
+    end
+
+    when_rendering :console do |output, nodename, options|
+      if output.is_a?(String)
+        output
+      else
+        JSON.pretty_generate output
+      end
+    end
+  end
+
+  action :environments do
+    summary 'Query environment sync status'
+    arguments '[environment]'
+
+    when_invoked do |*args|
+      options      = args.last
+      environments = classifier.get_environments
+
+      if args.length == 2
+        output << environments.select { |g| g['name'] == args.first }
+      elsif args.length == 1
+        output << environments
+      else
+        fail("wrong number of arguments (#{args.length-1} for 1)")
+      end
+      output.flatten
+    end
+
+    when_rendering :console do |output|
+      if output.length > 1
+        output
+      else
+        if output.first.class == Hash && output.first.has_key?('sync_succeeded')
+          output.first['sync_succeeded'].to_s
+        else
+          fail('Environment doesn\'t exist.')
+        end
+      end
+    end
+  end
+
+  def check_facts(file, options)
+    if file && options[:explain]
+      begin
+        contents  = YAML.load_file(file)
+        content ||= JSON.parse(File.read file)
+      rescue
+        fail "Could not file file '#{file}'"
+      else
+        contents
+      end
+    else
+      {}
+    end
+  end
+
+  def read_import(file)
+    begin
+      contents = JSON.parse(File.read file)
+    rescue
+      fail "Could not read file '#{file}'"
+    else
+      contents
+    end
+  end
+
+  def cap_class_name(k)
+    k.split('::').collect { |p| p.capitalize }.join('::')
+  end
+end


### PR DESCRIPTION
Added a face to cover the endpoints available to the classifier API:

+  classes
+  classified
+  environments
+  groups
+  unpin

For the moment, the idea is to be read-only- used for query purposes only.  The `unpin`  endpoint is the only endpoint that changes anything.  The reason being, I'm aiming to encourage changes through DSL instead of using the face.  However, if users would rather just update using the face, I'd be open to adding something like the following:

```
# puppet node_manager groups 'My Group' \
--classes '{ "foo" => {} }' \
--variables '{ "key" => "var" }'
```

...in order to update a group.  But this can be accomplished using the RAL in any case:

```
# puppet apply -e 'node_group { "My Group": classes => { "foo" => {} }, variables => { "key" => "var" }, }'