### PR TITLE
Added Console config_data support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,38 @@
 language: ruby
-env:
-  - PUPPET_VERSION=4.7.0
-  - PUPPET_VERSION=4.7.0
-  - PUPPET_VERSION=4.6.2
-  - PUPPET_VERSION=4.6.1
-  - PUPPET_VERSION=4.5.2
-  - PUPPET_VERSION=4.5.2
-  - PUPPET_VERSION=4.5.1
-  - PUPPET_VERSION=4.5.0
-  - PUPPET_VERSION=4.4.2
-  - PUPPET_VERSION=4.4.1
-  - PUPPET_VERSION=4.4.0
-  - PUPPET_VERSION=4.3.2
-  - PUPPET_VERSION=4.3.2
-  - PUPPET_VERSION=4.3.2
-  - PUPPET_VERSION=4.3.1
-  - PUPPET_VERSION=4.3.1
-  - PUPPET_VERSION=4.3.0
-  - PUPPET_VERSION=4.2.3
-  - PUPPET_VERSION=4.2.2
-  - PUPPET_VERSION=4.2.2
-  - PUPPET_VERSION=4.2.2
-  - PUPPET_VERSION=4.2.1
-  - PUPPET_VERSION=4.2.0
-  - PUPPET_VERSION=4.2.0
-  - PUPPET_VERSION=4.1.0
-  - PUPPET_VERSION=4.0.0
-  - PUPPET_VERSION=3.8.1
-  - PUPPET_VERSION=3.7.0
-rvm:
-  - 2.2.0
-  - 2.1.0
-  - 2.0.0
+matrix:
+  include:
+  # 2017.3.1
+  - rvm: 2.4.1
+    env: PUPPET_VERSION=5.3.1
+  # 2017.2.4
+  - rvm: 2.1.9
+    env: PUPPET_VERSION=4.10.8
+  # 2017.1.0
+  - rvm: 2.1.9
+    env: PUPPET_VERSION=4.9.4
+  # 2016.5.2
+  - rvm: 2.1.9
+    env: PUPPET_VERSION=4.8.2
+  # 2016.4.7
+  - rvm: 2.1.9
+    env: PUPPET_VERSION=4.10.5
+  # 2016.2.1
+  - rvm: 2.1.9
+    env: PUPPET_VERSION=4.5.2
+  # 2016.1.2
+  - rvm: 2.1.9
+    env: PUPPET_VERSION=4.4.2
+  # 2015.3.3
+  - rvm: 2.1.8
+    env: PUPPET_VERSION=4.3.2
+  # 2015.2.3
+  - rvm: 2.1.7
+    env: PUPPET_VERSION=4.2.3
+  # 3.8.6
+  - rvm: 2.1.7
+    env: PUPPET_VERSION=3.8.6
+  # 3.7.1
+  - rvm: 2.1.7
+    env: PUPPET_VERSION=3.7.1
 script:
   - "bundle exec rake spec"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2017-10-20 - Release 0.6.0
+
+### Summary
+
+- Added `pin` action to face
+- Added `data` parameter to `node_group` type for Console data
+- Added support for `data` parameter to `https` provider
+- Added `config_data` argument to puppet-less provider
+
 ## 2017-08-20 - Release 0.5.0
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -125,6 +125,20 @@ node_group { 'PE MCollective':
 
   Default (empty array): `[]`
 
+* `variables`
+
+  Global variables for the node group expressed in a hash as `{ 'var' => 'value' }`.
+
+  Default (empty hash): `{}`
+
+* `data`
+
+  Configuration data supplied for automatic parameter lookup for the group. 
+Data for the node group expressed in a hash as `{ 'class' => { 'param' => 'value' }}`.
+This parameter is supported for PE >=2017.3.x.
+
+  Default (empty hash): `{}`
+
 ## Functions
 
 ### node_groups()
@@ -142,7 +156,8 @@ Retrieve all or one node_group and its data.
     "rule"=>["and", ["~", "name", ".*"]],
     "variables"=>{}, "id"=>"00000000-0000-4000-8000-000000000000",
     "environment"=>"production",
-    "classes"=>{}
+    "classes"=>{},
+    "config_data"=>{}
   },
   "Production environment"=>{
     "environment_trumps"=>false,
@@ -152,7 +167,8 @@ Retrieve all or one node_group and its data.
     "variables"=>{},
     "id"=>"7233f964-951e-4a7f-88ea-72676ed3104d",
     "environment"=>"production",
-    "classes"=>{}
+    "classes"=>{},
+    "config_data"=>{}
   },
   ...
 }
@@ -169,7 +185,8 @@ Retrieve all or one node_group and its data.
     "rule"=>["and", ["~", "name", ".*"]],
     "variables"=>{}, "id"=>"00000000-0000-4000-8000-000000000000",
     "environment"=>"production",
-    "classes"=>{}
+    "classes"=>{},
+    "config_data"=>{}
   }
 }
   ```
@@ -199,6 +216,7 @@ ACTIONS:
   classified      List classification information
   environments    Query environment sync status
   groups          List group information
+  pin             Pin a node to a group
   unpin           Unpin a node from all groups
 
 See 'puppet man node_manager' or 'man puppet-node_manager' for full help.

--- a/lib/puppet/face/node_manager.rb
+++ b/lib/puppet/face/node_manager.rb
@@ -141,6 +141,40 @@ Puppet::Face.define(:node_manager, '0.1.0') do
     end
   end
 
+  action :pin do
+    summary 'Pin a node to a group'
+    arguments 'nodename'
+
+    option '--node_group GROUP' do
+      summary 'Node group to pin to'
+      default_to { '00000000-0000-4000-8000-000000000000' }
+    end
+
+    when_invoked do |*args|
+      nodename = args.first
+      options  = args.last
+      require 'pry'; binding.pry
+
+      if options[:node_group]
+        'Success' if classifier.pin_node(nodename, options[:node_group])
+      else
+      end
+    end
+
+    when_rendering :console do |output|
+      case output
+      when Hash
+        if output.length <= 1
+          JSON.pretty_generate output.values[0]
+        else
+          output.keys
+        end
+      else
+        output
+      end
+    end
+  end
+
   action :unpin do
     summary 'Unpin a node from all groups'
     arguments 'nodename'

--- a/lib/puppet/type/node_group.rb
+++ b/lib/puppet/type/node_group.rb
@@ -46,6 +46,17 @@ Puppet::Type.newtype(:node_group) do
       PuppetX::Node_manager::Common.sort_hash(value)
     end
   end
+  newproperty(:data) do
+    desc 'Data applied to this group'
+    #defaultto {}
+    validate do |value|
+      fail("Data must be supplied as a hash") unless value.is_a?(Hash)
+    end
+    # Need to deep sort hashes so they be evaluated equally
+    munge do |value|
+      PuppetX::Node_manager::Common.sort_hash(value)
+    end
+  end
   newproperty(:description) do
     desc 'Description of this group'
   end

--- a/lib/puppet/util/nc_https.rb
+++ b/lib/puppet/util/nc_https.rb
@@ -137,6 +137,18 @@ class Puppet::Util::Nc_https
     end
   end
 
+  def pin_node(node, group_id)
+    data = { 'nodes' => node, } 
+    res  = do_https("v1/groups/#{group_id}/pin", 'POST', data)
+    require 'pry'; binding.pry
+    if res.code.to_i != 204
+      Puppet.debug("Response code: #{res.code}")
+      Puppet.debug("Response message: #{res.body}")
+    else
+      JSON.parse(res.body)
+    end
+  end
+
   def unpin_from_all(node)
     data = { 'nodes' => [node] }
     res  = do_https('v1/commands/unpin-from-all', 'POST', data)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "WhatsARanjit-node_manager",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "WhatsARanjit",
   "summary": "Create and manage PE Console node groups as resources.",
   "license": "Apache-2.0",
@@ -50,7 +50,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.7.1 < 5.0.0"
+      "version_requirement": ">= 3.7.1 < 6.0.0"
     }
   ],
   "description": "Node_manager module"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -61,6 +61,9 @@ Usage: ./node_group.sh [options] [UID]
  -v| --variables    Variables to set in the group.
                 Example: '{ "foo": "bar" }'
 
+ -a| --config_data    Configuration data for the group.
+                Example: '{ "vim": { "vim_package": "vim-common" } }'
+
  -h| --help      Display this help message.
  ```
 

--- a/scripts/node_group.sh
+++ b/scripts/node_group.sh
@@ -22,6 +22,8 @@ Usage: $0 [options] [UID]\n
 \t                   \t\t Example: '["or", ["=", "name", "node.whatsaranjit.com"]]'\n\n
 -v| --variables        \t Variables to set in the group.\n
 \t                   \t\t Example: '{ "foo": "bar" }'\n\n
+-a| --config_data      \t Configuration data for the group.\n
+\t                   \t\t Example: '{ "vim": { "vim_package": "vim-common" } }'\n\n
 -h| --help           \t\t Display this help message.\n
 EOF`
 
@@ -108,6 +110,11 @@ else
       -v|--variables)
       VARIABLES="$2"
       DATA="${DATA} \"variables\": $VARIABLES,"
+      shift
+      ;;
+      -a|--config_data)
+      CONFIG_DATA="$2"
+      DATA="${DATA} \"config_data\": ${CONFIG_DATA},"
       shift
       ;;
       *)


### PR DESCRIPTION
## 2017-10-20 - Release 0.6.0

### Summary

- Added `pin` action to face
- Added `data` parameter to `node_group` type for Console data
- Added support for `data` parameter to `https` provider
- Added `config_data` argument to puppet-less provider