### PR TITLE
Show errors when unable to create node group

### DIFF
--- a/lib/puppet/util/nc_https.rb
+++ b/lib/puppet/util/nc_https.rb
@@ -48,8 +48,8 @@ class Puppet::Util::Nc_https
     endpoint = data.has_key?('id') ? "v1/groups/#{data['id']}" : 'v1/groups'
     res = do_https(endpoint, 'POST', data)
     if res.code.to_i != 303
-      Puppet.debug("Response code: #{res.code}")
-      Puppet.debug("Response message: #{res.body}")
+      Puppet.err("Response code: #{res.code}")
+      Puppet.err("Response message: #{res.body}")
       fail("Unable to create node_group '#{data['name']}'")
     else
       new_UID = res['location'].split('/')[-1]


### PR DESCRIPTION
Currently, the specifics of a failure to create a node group are only
logged at debug. This kind of error should be surfaced to the user so
that if something goes wrong, it's apparent what it was.

This commit makes API create errors print, should errors occur.