### PR TITLE
Fixes for `bolt apply`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,7 @@ source "https://rubygems.org"
 
 group :test do
   gem "rake"
-#  gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.3'
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
-#  gem "puppetlabs_spec_helper"
   gem 'rspec-puppet-utils', :git => 'https://github.com/Accuity/rspec-puppet-utils.git'
   gem 'hiera-puppet-helper', :git => 'https://github.com/bobtfish/hiera-puppet-helper.git'
   # there seems to be a bug with puppet-blacksmith and metadata-json-lint
@@ -26,6 +24,6 @@ end
 source 'https://rubygems.org'
 
 gem 'puppet', nil || ENV['PUPPET_VERSION']
-gem 'puppetlabs_spec_helper', '0.10.3'
+gem 'puppetlabs_spec_helper', '2.13.1'
 gem 'webmock', '1.22.1'
 gem 'puppetclassify', '0.1.7'

--- a/lib/puppet/util/node_groups.rb
+++ b/lib/puppet/util/node_groups.rb
@@ -20,11 +20,18 @@ class Puppet::Util::Node_groups < parent
       "private_key_path"    => Puppet.settings['hostprivkey'],
     }
 
+    classifier_yaml = [
+      File.join(Puppet.settings['confdir'], 'classifier.yaml'),
+      '/etc/puppetlabs/puppet/classifier.yaml',
+    ].find { |file| File.exist?(file) }
+
+    fail "node_manager: could not find classifier.yaml" if classifier_yaml.nil?
+
     begin
-      nc_settings = YAML.load_file("#{Puppet.settings['confdir']}/classifier.yaml")
-      nc_settings = nc_settings.first if nc_settings.class == Array            
+      nc_settings = YAML.load_file(classifier_yaml)
+      nc_settings = nc_settings.first if nc_settings.class == Array
     rescue
-      fail "Could not find file #{Puppet.settings['confdir']}/classifier.yaml"
+      fail "Could not load file #{classifier_yaml}"
     else
       classifier_url = "https://#{nc_settings['server']}:#{nc_settings['port']}/classifier-api"
     end

--- a/spec/functions/node_groups_spec.rb
+++ b/spec/functions/node_groups_spec.rb
@@ -71,20 +71,8 @@ describe 'node_groups' do
   }
 
   before do
-    YAML.stubs(:load_file).returns({
-      'server' => 'stubserver',
-      'port'   => '8080',
-    })
-    stub_request(
-      :get,
-      'https://stubserver:8080/classifier-api/v1/groups',
-    ).to_return(
-      :status => 200,
-      :body   => groups_response
-    )
-    File.stubs(:read).returns('helloworld')
-    OpenSSL::X509::Certificate.stubs(:new) {mock_model(OpenSSL::X509::Certificate, :save => true)}
-    OpenSSL::PKey::RSA.stubs(:new) {mock_model(OpenSSL::PKey::RSA, :save => true)}
+    nc = double("NC", :get_groups => JSON.parse(groups_response))
+    allow(Puppet::Util::Nc_https).to receive(:new).and_return(nc)
   end
 
   describe 'without an argument' do

--- a/spec/integration/puppet/provider/node_group/https_spec.rb
+++ b/spec/integration/puppet/provider/node_group/https_spec.rb
@@ -1,4 +1,4 @@
-require 'puppetlabs_spec_helper/module_spec_helper'
+require 'spec_helper'
 require 'webmock/rspec'
 
 describe Puppet::Type.type(:node_group).provider(:https) do
@@ -58,11 +58,19 @@ describe Puppet::Type.type(:node_group).provider(:https) do
   end
 
   before do
-      YAML.stubs(:load_file).with('/dev/null/classifier.yaml')
-        .returns({'server' => 'stubserver', 'port' => '8080'})
-    File.stubs(:read).returns('helloworld')
-    OpenSSL::X509::Certificate.stubs(:new) {mock_model(OpenSSL::X509::Certificate, :save => true)}
-    OpenSSL::PKey::RSA.stubs(:new) {mock_model(OpenSSL::PKey::RSA, :save => true)}
+    allow(File).to receive(:exist?).and_return(false)
+    allow(File).to receive(:exist?).with('/dev/null/classifier.yaml').and_return(true)
+    allow(File).to receive(:exist?).with('/dev/null/certificate.pem').and_return(true)
+    allow(File).to receive(:read).and_return('helloworld')
+    allow(OpenSSL::X509::Certificate).to receive(:new).and_return(double("Cert", :save => true))
+    allow(OpenSSL::PKey::RSA).to receive(:new).and_return(double("Key", :save => true))
+    allow(YAML).to receive(:load_file).with('/dev/null/classifier.yaml').and_return({
+      'server'      => 'stubserver',
+      'port'        => '8080',
+      'localcacert' => '/dev/null/certificate.pem',
+      'hostcert'    => '/dev/null/certificate.pem',
+      'hostprivkey' => '/dev/null/certificate.pem',
+    })
   end
 
   describe "#instances" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,9 @@ require 'rspec-puppet-utils'
 # Uncomment this to show coverage report, also useful for debugging
 #at_exit { RSpec::Puppet::Coverage.report! }
 
-#RSpec.configure do |c|
-#    c.formatter = 'documentation'
-#    config.mock_with :rspec
-#end
+RSpec.configure do |config|
+  config.mock_with :rspec
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
This PR improves node_manager's ability to locate and use Puppet certificate files, when necessary, including in the circumstance that `Puppet.settings[]` do not hold any valid values.

This is needed to allow node_manager to work when used with `bolt apply`. When Bolt performs an `apply` Puppet run, it invokes Puppet on the target system with a temporary, isolated confdir. Thus, normal `Puppet.settings[]` values are unavailable.