### PR TITLE
Update metadata to indicate compatibility with Puppet 6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "WhatsARanjit-node_manager",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": "WhatsARanjit",
   "summary": "Create and manage PE Console node groups as resources.",
   "license": "Apache-2.0",
@@ -50,7 +50,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.7.1 < 6.0.0"
+      "version_requirement": ">= 3.7.1 < 7.0.0"
     }
   ],
   "description": "Node_manager module"


### PR DESCRIPTION
Tested that this module works when the agent version is 6.0.9.  This commit updates the metadata to indicate that compatibility is Puppet less than seven, rather than six.