### PR TITLE
Quotes causing false to be treated as a string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ node_group { 'PE MCollective':
   classes              => {'puppet_enterprise::profile::mcollective::agent' => {}},
   environment          => 'production',
   id                   => '4cdec347-20c6-46d7-9658-7189c1537ae9',
-  override_environment => 'false',
+  override_environment => false,
   parent               => 'PE Infrastructure',
   rule                 => ['and', ['~', ['fact', 'pe_version'], '.+']],
 }


### PR DESCRIPTION
```override_environment => 'false',``` in the README is confusing as the quotes mean the false is interpreted as a string not a boolean.