### PR TITLE
Implement `purge_behavior` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add `purge_behavior` parameter to node\_group resource type
+
 ## 2019-12-27 - Release 0.7.3
 
 ## Summary

--- a/Gemfile
+++ b/Gemfile
@@ -27,5 +27,5 @@ source 'https://rubygems.org'
 
 gem 'puppet', nil || ENV['PUPPET_VERSION']
 gem 'puppetlabs_spec_helper'
-gem 'webmock', '1.22.1'
+gem 'webmock'
 gem 'puppetclassify', '0.1.7'

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source "https://rubygems.org"
+gem 'pry'
 
 group :test do
   gem "rake"
 #  gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.3'
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
-#  gem "puppetlabs_spec_helper"
   gem 'rspec-puppet-utils', :git => 'https://github.com/Accuity/rspec-puppet-utils.git'
   gem 'hiera-puppet-helper', :git => 'https://github.com/bobtfish/hiera-puppet-helper.git'
   # there seems to be a bug with puppet-blacksmith and metadata-json-lint
@@ -26,6 +26,6 @@ end
 source 'https://rubygems.org'
 
 gem 'puppet', nil || ENV['PUPPET_VERSION']
-gem 'puppetlabs_spec_helper', '0.10.3'
+gem 'puppetlabs_spec_helper'
 gem 'webmock', '1.22.1'
 gem 'puppetclassify', '0.1.7'

--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ This parameter is supported for PE >=2017.3.x.
 
   Default (empty hash): `{}`
 
+* `purge_behavior`
+
+  Defines how purging of classification or data will be handled. By default, or when set to `all`, the node\_group resource will ensure classes and data are matched exactly, and remove any values not described by the resource. When set to `none`, the node\_group resource will ensure data and classes described are present with the prescribed values, but will not remove other classification, or other data, present in the node group. The `data` setting purges only data values, and the `classes` setting purges only classes values.
+
+  Default: `all`
+
+  Values: `all`, `data`, `classes`, `none`
+
 ## Tasks
 
 ### update_classes

--- a/lib/puppet/type/node_group.rb
+++ b/lib/puppet/type/node_group.rb
@@ -61,10 +61,6 @@ Puppet::Type.newtype(:node_group) do
         PuppetX::Node_manager::Common.sort_hash(merged)
       end
     end
-    def insync?(is)
-      [is, should].map { |val| PuppetX::Node_manager::Common.sort_hash(val) }
-                  .reduce { |a,b| a == b }
-    end
   end
   newproperty(:data) do
     desc 'Data applied to this group'
@@ -86,10 +82,6 @@ Puppet::Type.newtype(:node_group) do
         merged = a.merge(b) { |k, x, y| x.merge(y) }
         PuppetX::Node_manager::Common.sort_hash(merged)
       end
-    end
-    def insync?(is)
-      [is, should].map { |val| PuppetX::Node_manager::Common.sort_hash(val) }
-                  .reduce { |a,b| a == b }
     end
   end
   newproperty(:description) do

--- a/lib/puppet/type/node_group.rb
+++ b/lib/puppet/type/node_group.rb
@@ -55,12 +55,9 @@ Puppet::Type.newtype(:node_group) do
       when :classes, :all
         super
       else
-        a = @resource.property(:data).retrieve || {}
+        a = @resource.property(:classes).retrieve || {}
         b = shouldorig.first
-        merged = (a.keys + b.keys).uniq.reduce({}) do |memo,key|
-          memo[key] = a[key] && b[key] ? a[key].merge(b[key]) : a[key] || b[key]
-          memo
-        end
+        merged = a.merge(b) { |k, x, y| x.merge(y) }
         PuppetX::Node_manager::Common.sort_hash(merged)
       end
     end
@@ -86,10 +83,7 @@ Puppet::Type.newtype(:node_group) do
       else
         a = @resource.property(:data).retrieve || {}
         b = shouldorig.first
-        merged = (a.keys + b.keys).uniq.reduce({}) do |memo,key|
-          memo[key] = a[key] && b[key] ? a[key].merge(b[key]) : a[key] || b[key]
-          memo
-        end
+        merged = a.merge(b) { |k, x, y| x.merge(y) }
         PuppetX::Node_manager::Common.sort_hash(merged)
       end
     end

--- a/spec/integration/puppet/provider/node_group/https_spec.rb
+++ b/spec/integration/puppet/provider/node_group/https_spec.rb
@@ -1,4 +1,4 @@
-require 'puppetlabs_spec_helper/module_spec_helper'
+require 'spec_helper'
 require 'webmock/rspec'
 
 describe Puppet::Type.type(:node_group).provider(:https) do
@@ -58,11 +58,18 @@ describe Puppet::Type.type(:node_group).provider(:https) do
   end
 
   before do
-      YAML.stubs(:load_file).with('/dev/null/classifier.yaml')
-        .returns({'server' => 'stubserver', 'port' => '8080'})
-    File.stubs(:read).returns('helloworld')
-    OpenSSL::X509::Certificate.stubs(:new) {mock_model(OpenSSL::X509::Certificate, :save => true)}
-    OpenSSL::PKey::RSA.stubs(:new) {mock_model(OpenSSL::PKey::RSA, :save => true)}
+    allow(YAML).to(receive(:load_file))
+               .with('/dev/null/classifier.yaml')
+               .and_return({'server' => 'stubserver', 'port' => '8080'})
+
+    allow(File).to receive(:read).and_call_original
+    allow(File).to receive(:read).with(%r{/dev/null/ssl/}).and_return('helloworld')
+
+    allow(OpenSSL::X509::Certificate).to(receive(:new))
+                                     .and_return(double("Certificate", :save => true))
+
+    allow(OpenSSL::PKey::RSA).to(receive(:new))
+                             .and_return(double("Key", :save => true))
   end
 
   describe "#instances" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,11 @@
-require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-utils'
 
 # Uncomment this to show coverage report, also useful for debugging
 #at_exit { RSpec::Puppet::Coverage.report! }
 
-#RSpec.configure do |c|
-#    c.formatter = 'documentation'
-#    config.mock_with :rspec
-#end
+RSpec.configure do |c|
+  c.mock_with :rspec
+  c.mock_framework = :rspec
+end
+
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/spec/unit/puppet/type/node_group_spec.rb
+++ b/spec/unit/puppet/type/node_group_spec.rb
@@ -91,96 +91,65 @@ describe Puppet::Type.type(:node_group) do
     end
 
     let(:existing_data) do
-      {
-        'data::class1' => { 'param1' => 'existing',
+      { 'data::class1' => { 'param1' => 'existing',
                             'param3' => 'existing' },
         'data::class3' => { 'param1' => 'existing',
-                            'param2' => 'existing' },
-      }
+                            'param2' => 'existing' }}
+    end
+    let(:merged_data) do
+      { "data::class1" => { "param1" => "resource",
+                            "param2" => "resource",
+                            "param3" => "existing"},
+        "data::class2" => { "param1" => "resource",
+                            "param2" => "resource"},
+        "data::class3" => { "param1" => "existing",
+                            "param2" => "existing"}}
     end
 
     let(:existing_classes) do
-      {
-        'classes::class1' => { 'param1' => 'existing',
+      { 'classes::class1' => { 'param1' => 'existing',
                                'param3' => 'existing' },
         'classes::class3' => { 'param1' => 'existing',
-                               'param2' => 'existing' },
-      }
+                               'param2' => 'existing' }}
+    end
+    let(:merged_classes) do
+      { "classes::class1" => { "param1" => "resource",
+                               "param2" => "resource",
+                               "param3" => "existing"},
+        "classes::class3" => { "param1" => "existing",
+                               "param2" => "existing"}}
     end
 
     it "should match classes and data exactly by default" do
-      resource = described_class.new(resource_hash)
-
-      allow(resource.property(:data)).to receive(:retrieve).and_return(existing_data)
-      allow(resource.property(:classes)).to receive(:retrieve).and_return(existing_classes)
-
-      data_should = resource.property(:data).should
-      classes_should = resource.property(:classes).should
-
-      expect(data_should).to eq resource_hash[:data]
-      expect(classes_should).to eq resource_hash[:classes]
+      rsrc = described_class.new(resource_hash)
+      allow(rsrc.property(:data)).to receive(:retrieve).and_return(existing_data)
+      allow(rsrc.property(:classes)).to receive(:retrieve).and_return(existing_classes)
+      expect(rsrc.property(:data).should).to eq resource_hash[:data]
+      expect(rsrc.property(:classes).should).to eq resource_hash[:classes]
     end
 
     it "should merge in classes and data when set to :none" do
-      resource = described_class.new(resource_hash.merge(:purge_behavior => 'none'))
-
-      allow(resource.property(:data)).to receive(:retrieve).and_return(existing_data)
-      allow(resource.property(:classes)).to receive(:retrieve).and_return(existing_classes)
-
-      data_should = resource.property(:data).should
-      classes_should = resource.property(:classes).should
-
-      expect(data_should).to eq ({ "data::class1" => { "param1" => "resource",
-                                                       "param2" => "resource",
-                                                       "param3" => "existing"},
-                                   "data::class2" => { "param1" => "resource",
-                                                       "param2" => "resource"},
-                                   "data::class3" => { "param1" => "existing",
-                                                       "param2" => "existing"}})
-
-      expect(classes_should).to eq ({ "classes::class1" => { "param1" => "resource",
-                                                             "param2" => "resource",
-                                                             "param3" => "existing"},
-                                      "classes::class3" => { "param1" => "existing",
-                                                             "param2" => "existing"}})
+      rsrc = described_class.new(resource_hash.merge(:purge_behavior => 'none'))
+      allow(rsrc.property(:data)).to receive(:retrieve).and_return(existing_data)
+      allow(rsrc.property(:classes)).to receive(:retrieve).and_return(existing_classes)
+      expect(rsrc.property(:data).should).to eq (merged_data)
+      expect(rsrc.property(:classes).should).to eq (merged_classes)
     end
 
     it "should merge in classes and match data exactly when set to :data" do
-      resource = described_class.new(resource_hash.merge(:purge_behavior => 'data'))
-
-      allow(resource.property(:data)).to receive(:retrieve).and_return(existing_data)
-      allow(resource.property(:classes)).to receive(:retrieve).and_return(existing_classes)
-
-      data_should = resource.property(:data).should
-      classes_should = resource.property(:classes).should
-
-      expect(data_should).to eq (resource_hash[:data])
-
-      expect(classes_should).to eq ({ "classes::class1" => { "param1" => "resource",
-                                                             "param2" => "resource",
-                                                             "param3" => "existing"},
-                                      "classes::class3" => { "param1" => "existing",
-                                                             "param2" => "existing"}})
+      rsrc = described_class.new(resource_hash.merge(:purge_behavior => 'data'))
+      allow(rsrc.property(:data)).to receive(:retrieve).and_return(existing_data)
+      allow(rsrc.property(:classes)).to receive(:retrieve).and_return(existing_classes)
+      expect(rsrc.property(:data).should).to eq (resource_hash[:data])
+      expect(rsrc.property(:classes).should).to eq (merged_classes)
     end
 
     it "should merge in data and match classes exactly when set to :classes" do
-      resource = described_class.new(resource_hash.merge(:purge_behavior => 'classes'))
-
-      allow(resource.property(:data)).to receive(:retrieve).and_return(existing_data)
-      allow(resource.property(:classes)).to receive(:retrieve).and_return(existing_classes)
-
-      data_should = resource.property(:data).should
-      classes_should = resource.property(:classes).should
-
-      expect(data_should).to eq ({ "data::class1" => { "param1" => "resource",
-                                                       "param2" => "resource",
-                                                       "param3" => "existing"},
-                                   "data::class2" => { "param1" => "resource",
-                                                       "param2" => "resource"},
-                                   "data::class3" => { "param1" => "existing",
-                                                       "param2" => "existing"}})
-
-      expect(classes_should).to eq (resource_hash[:classes])
+      rsrc = described_class.new(resource_hash.merge(:purge_behavior => 'classes'))
+      allow(rsrc.property(:data)).to receive(:retrieve).and_return(existing_data)
+      allow(rsrc.property(:classes)).to receive(:retrieve).and_return(existing_classes)
+      expect(rsrc.property(:data).should).to eq (merged_data)
+      expect(rsrc.property(:classes).should).to eq (resource_hash[:classes])
     end
   end
 

--- a/spec/unit/puppet/type/node_group_spec.rb
+++ b/spec/unit/puppet/type/node_group_spec.rb
@@ -1,11 +1,5 @@
 require 'spec_helper'
 
-# This should be moved to spec_helper when/if Mocha is verified removed from
-# all other tests
-RSpec.configure do |c|
-  c.mock_framework = :rspec
-end
-
 describe Puppet::Type.type(:node_group) do
   it "should allow agent-specified environment" do
     expect {

--- a/spec/unit/puppet/type/node_group_spec.rb
+++ b/spec/unit/puppet/type/node_group_spec.rb
@@ -1,7 +1,12 @@
-require 'puppetlabs_spec_helper/module_spec_helper'
+require 'spec_helper'
+
+# This should be moved to spec_helper when/if Mocha is verified removed from
+# all other tests
+RSpec.configure do |c|
+  c.mock_framework = :rspec
+end
 
 describe Puppet::Type.type(:node_group) do
-
   it "should allow agent-specified environment" do
     expect {
       Puppet::Type.type(:node_group).new(
@@ -71,6 +76,118 @@ describe Puppet::Type.type(:node_group) do
         :description => 'Sample message',
       )
     }.to_not raise_error
+  end
+
+  describe "purge_behavior" do
+    let(:resource_hash) do
+      {
+        :name        => 'test_group',
+        :environment => 'test_env',
+        :data        => {
+          'data::class1' => { 'param1' => 'resource',
+                              'param2' => 'resource' },
+          'data::class2' => { 'param1' => 'resource',
+                              'param2' => 'resource' },
+        },
+        :classes     => {
+          'classes::class1' => { 'param1' => 'resource',
+                                 'param2' => 'resource' },
+        },
+      }
+    end
+
+    let(:existing_data) do
+      {
+        'data::class1' => { 'param1' => 'existing',
+                            'param3' => 'existing' },
+        'data::class3' => { 'param1' => 'existing',
+                            'param2' => 'existing' },
+      }
+    end
+
+    let(:existing_classes) do
+      {
+        'classes::class1' => { 'param1' => 'existing',
+                               'param3' => 'existing' },
+        'classes::class3' => { 'param1' => 'existing',
+                               'param2' => 'existing' },
+      }
+    end
+
+    it "should match classes and data exactly by default" do
+      resource = described_class.new(resource_hash)
+
+      allow(resource.property(:data)).to receive(:retrieve).and_return(existing_data)
+      allow(resource.property(:classes)).to receive(:retrieve).and_return(existing_classes)
+
+      data_should = resource.property(:data).should
+      classes_should = resource.property(:classes).should
+
+      expect(data_should).to eq resource_hash[:data]
+      expect(classes_should).to eq resource_hash[:classes]
+    end
+
+    it "should merge in classes and data when set to :none" do
+      resource = described_class.new(resource_hash.merge(:purge_behavior => 'none'))
+
+      allow(resource.property(:data)).to receive(:retrieve).and_return(existing_data)
+      allow(resource.property(:classes)).to receive(:retrieve).and_return(existing_classes)
+
+      data_should = resource.property(:data).should
+      classes_should = resource.property(:classes).should
+
+      expect(data_should).to eq ({ "data::class1" => { "param1" => "resource",
+                                                       "param2" => "resource",
+                                                       "param3" => "existing"},
+                                   "data::class2" => { "param1" => "resource",
+                                                       "param2" => "resource"},
+                                   "data::class3" => { "param1" => "existing",
+                                                       "param2" => "existing"}})
+
+      expect(classes_should).to eq ({ "classes::class1" => { "param1" => "resource",
+                                                             "param2" => "resource",
+                                                             "param3" => "existing"},
+                                      "classes::class3" => { "param1" => "existing",
+                                                             "param2" => "existing"}})
+    end
+
+    it "should merge in classes and match data exactly when set to :data" do
+      resource = described_class.new(resource_hash.merge(:purge_behavior => 'data'))
+
+      allow(resource.property(:data)).to receive(:retrieve).and_return(existing_data)
+      allow(resource.property(:classes)).to receive(:retrieve).and_return(existing_classes)
+
+      data_should = resource.property(:data).should
+      classes_should = resource.property(:classes).should
+
+      expect(data_should).to eq (resource_hash[:data])
+
+      expect(classes_should).to eq ({ "classes::class1" => { "param1" => "resource",
+                                                             "param2" => "resource",
+                                                             "param3" => "existing"},
+                                      "classes::class3" => { "param1" => "existing",
+                                                             "param2" => "existing"}})
+    end
+
+    it "should merge in data and match classes exactly when set to :classes" do
+      resource = described_class.new(resource_hash.merge(:purge_behavior => 'classes'))
+
+      allow(resource.property(:data)).to receive(:retrieve).and_return(existing_data)
+      allow(resource.property(:classes)).to receive(:retrieve).and_return(existing_classes)
+
+      data_should = resource.property(:data).should
+      classes_should = resource.property(:classes).should
+
+      expect(data_should).to eq ({ "data::class1" => { "param1" => "resource",
+                                                       "param2" => "resource",
+                                                       "param3" => "existing"},
+                                   "data::class2" => { "param1" => "resource",
+                                                       "param2" => "resource"},
+                                   "data::class3" => { "param1" => "existing",
+                                                       "param2" => "existing"}})
+
+      expect(classes_should).to eq (resource_hash[:classes])
+    end
   end
 
 end


### PR DESCRIPTION
This allows for specifying classes or data keys that should be present or have defined values, without removing or modifying other data already present in the node group.