### PR TITLE
Allow string bool input for override_environment

### DIFF
--- a/lib/puppet/provider/node_group/https.rb
+++ b/lib/puppet/provider/node_group/https.rb
@@ -77,14 +77,13 @@ Puppet::Type.type(:node_group).provide(:https) do
     @noflush = true
     # Only passing parameters that are given
     send_data = Hash.new
-    @resource.original_parameters.each do |k,v|
-      next if [:ensure, :provider, :purge_behavior].include? k
-      next if @resource.parameter(k).metaparam?
-      key = k.to_s
+    @resource.properties.each do |property|
+      next if [:ensure].include? property.name
+      key = property.to_s
       # key changed for usability
       key = 'environment_trumps' if key == 'override_environment'
       key = 'config_data'        if key == 'data'
-      send_data[key] = v
+      send_data[key] = property.value
     end
     # namevar may not be in this hash
     send_data['name'] = @resource[:name] unless send_data['name']

--- a/lib/puppet/type/node_group.rb
+++ b/lib/puppet/type/node_group.rb
@@ -1,4 +1,5 @@
 require 'puppet_x/node_manager/common'
+require 'puppet/property/boolean'
 
 Puppet::Type.newtype(:node_group) do
   desc 'The node_group type creates and manages node groups for the PE Node Manager'
@@ -17,9 +18,8 @@ Puppet::Type.newtype(:node_group) do
       fail("ID is read-only")
     end
   end
-  newproperty(:override_environment) do
+  newproperty(:override_environment, :boolean => true, :parent => Puppet::Property::Boolean) do
     desc 'Override parent environments'
-    newvalues(:false, :true)
   end
   newproperty(:parent) do
     desc 'The ID of the parent group'

--- a/spec/integration/puppet/provider/node_group/https_spec.rb
+++ b/spec/integration/puppet/provider/node_group/https_spec.rb
@@ -27,15 +27,15 @@ describe Puppet::Type.type(:node_group).provider(:https) do
   EOS
 
   HCREATE_REQUEST = {
-    "environment_trumps" => "false",
+    "environment_trumps" => false,
     "parent"             => "00000000-0000-4000-8000-000000000000",
-    "rule"               => ["or", ["=", "name", "master.puppetlabs.vm"]],
-    "environment"        => "stubenvironment",
-    "classes"            => {"puppet_enterprise::profile::amq::broker" => {}},
     "variables"          => {
       "stubkey"  => "stubvalue",
       "stubkey2" => "stubvalue2"
     },
+    "rule"               => ["or", ["=", "name", "master.puppetlabs.vm"]],
+    "environment"        => "stubenvironment",
+    "classes"            => {"puppet_enterprise::profile::amq::broker" => {}},
     "description"        => "Sample message",
     "name"               => "stub_name",
   }.to_json


### PR DESCRIPTION
This is mostly to make it so that the output of `puppet resource node_group`, for the `override_environment` parameter, is valid input.

The output of `puppet resource` shows a string type value for the environment_override parameter. However, a string is not a valid input for the classifier's REST API. The API only accepts boolean data types. If a string like "true" is passed through all the way to the API, an error will occur and the type won't work.

This commit adds a munge method to the boolean type to internally convert use input of strings, actual booleans, etc. to Boolean type values. This ensures that valid data is passed to the classifier API, and also happens to validate user input.

Some cleanup was required in the https provider's create method to make this work. Previously the provider used @resource.original_parameters instead of @resource.properties, so cleaup (munging) wasn't being benefited from.

The spec test had to be changed to submit valid input (a string "false" to environment_trumps was never valid input to begin with, so this is a positive test change), and also to adjust order of keys submitted.  Apparently webmock is very sensitive to that.