### PR TITLE
Fixes bad schema issues with purge_behavior

### DIFF
--- a/lib/puppet/provider/node_group/https.rb
+++ b/lib/puppet/provider/node_group/https.rb
@@ -78,7 +78,7 @@ Puppet::Type.type(:node_group).provide(:https) do
     # Only passing parameters that are given
     send_data = Hash.new
     @resource.original_parameters.each do |k,v|
-      next if [:ensure, :provider].include? k
+      next if [:ensure, :provider, :purge_behavior].include? k
       next if @resource.parameter(k).metaparam?
       key = k.to_s
       # key changed for usability


### PR DESCRIPTION
	With the merge of GH-60 adding node_groups fails with a schema
	error when it sends the purge_behavior parameter and is rejected
	by classifier.

	This commit adds purge_behavior to the list of filtered
	parameters that are built into the data structure sent to the
	classifier API.