### PR TITLE
Force override_environment to a symbol to maintain idempotency.

### DIFF
--- a/lib/puppet/provider/node_group/https.rb
+++ b/lib/puppet/provider/node_group/https.rb
@@ -89,6 +89,8 @@ Puppet::Type.type(:node_group).provide(:https) do
     send_data['name'] = @resource[:name] unless send_data['name']
     # Passing an empty hash in the type results in undef
     send_data['classes'] = {} unless send_data['classes']
+    # Ensure environment_trumps is a boolean
+    send_data['environment_trumps'] = Puppet::Coercion.boolean(send_data['environment_trumps']) if send_data['environment_trumps']
 
     send_data['parent'] = '00000000-0000-4000-8000-000000000000' if !send_data['parent']
     unless send_data['parent'] =~ /^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$/

--- a/lib/puppet/type/node_group.rb
+++ b/lib/puppet/type/node_group.rb
@@ -18,8 +18,11 @@ Puppet::Type.newtype(:node_group) do
       fail("ID is read-only")
     end
   end
-  newproperty(:override_environment, :boolean => true, :parent => Puppet::Property::Boolean) do
+  newproperty(:override_environment, :boolean => true) do
     desc 'Override parent environments'
+    munge do |value|
+      Puppet::Coercion.boolean(value).to_s.to_sym
+    end
   end
   newproperty(:parent) do
     desc 'The ID of the parent group'


### PR DESCRIPTION
This fix addresses a problem where override_environment was not idempotent in two ways:

'true' and true would always fail to match.
Current state of true and desired state of false would not set the desired state.