### PR TITLE
Added ability to set the purge behavior for node group rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,11 @@ This parameter is supported for PE >=2017.3.x.
 
 * `purge_behavior`
 
-  Defines how purging of classification or data will be handled. By default, or when set to `all`, the node\_group resource will ensure classes and data are matched exactly, and remove any values not described by the resource. When set to `none`, the node\_group resource will ensure data and classes described are present with the prescribed values, but will not remove other classification, or other data, present in the node group. The `data` setting purges only data values, and the `classes` setting purges only classes values.
+  Defines how purging of classification, data and rules will be handled. By default, or when set to `all`, the node\_group resource will ensure classes, data and rules are matched exactly, and remove any values not described by the resource. When set to `none`, the node\_group resource will ensure data, classes and rules described are present with the prescribed values, but will not remove other classification, or other data, present in the node group. The `data` setting purges only data values, the `classes` setting purges only classes values and the `rule` setting purges only rule values. In case of conflict with the node classifiers `Nodes must match all rules.` and `Nodes may match any rule.` radio buttons. The node classifier takes precedence over defined node_group code.
 
   Default: `all`
 
-  Values: `all`, `data`, `classes`, `none`
+  Values: `all`, `data`, `classes`, `rule`, `none`
 
 ## Tasks
 

--- a/lib/puppet/type/node_group.rb
+++ b/lib/puppet/type/node_group.rb
@@ -9,7 +9,7 @@ Puppet::Type.newtype(:node_group) do
   end
   newparam(:purge_behavior) do
     desc 'Whether or not to remove data or class parameters not specified'
-    newvalues(:none, :data, :classes, :all)
+    newvalues(:none, :data, :classes, :rule, :all)
     defaultto :all
   end
   newproperty(:id) do
@@ -35,6 +35,45 @@ Puppet::Type.newtype(:node_group) do
   end
   newproperty(:rule, :array_matching => :all) do
     desc 'Match conditions for this group'
+    defaultto []
+    def should
+      case @resource[:purge_behavior]
+      when :rule, :all
+        super
+      else
+        a = shouldorig
+        b = @resource.property(:rule).retrieve || {}
+        # check if the node classifer has any rules defined before attempting merge.
+        if b.length >= 2
+          if b[0] == "or" and b[1][0] == "or" or b[1][0] == "and"
+            # We are merging both rules and pinned nodes
+            rules = (b[1] + a[1].drop(1)).uniq
+            pinned = (a[2,a.length] + b[2,b.length]).uniq
+            b[1] = rules
+            merged = (b + pinned).uniq
+          elsif a[0] == "or" and a[1][0] == "or" or a[1][0] == "and"
+            # We are merging both rules and pinned nodes
+            rules = a[1] # no rules to merge on B side
+            pinned = (a[2,a.length] + b[2,b.length]).uniq
+            merged = (a + pinned).uniq
+          else
+            # We are only doing rules OR pinned nodes
+            merged = (a + b.drop(1)).uniq
+          end
+          if merged == b
+            # values are the same, returning orginal value"
+            b
+          else
+            merged
+          end
+        else
+          a
+        end
+      end
+    end
+    def insync?(is)
+      is == should
+    end
   end
   newproperty(:environment) do
     desc 'Environment for this group'

--- a/lib/puppet_x/node_manager/common.rb
+++ b/lib/puppet_x/node_manager/common.rb
@@ -30,4 +30,19 @@ module PuppetX::Node_manager::Common
     end
     newhash
   end
+
+  # check for fact rules in deep array
+  def self.factcheck(rulecheck)
+    rulecheck.each_with_index {|x, i|
+    if x == "fact" and i == 0
+      return true
+    end
+    if x.kind_of?(Array)
+      if factcheck(x)
+        return true
+      end
+    end
+    }
+    false
+  end
 end


### PR DESCRIPTION
When using node_manager to manage a node_group; users lose the ability to pin nodes and modify rules via the PE console. This is inconvenient for users who wish to use node_manager to create node groups; however still require the flexibility to pin nodes and customise rules via the PE console.

This PR introduces the following behavior changes to the node_manager module.

When purge_behavior is set to "all", "data", "classes" or unset. There is no change to the behavior of this module.
When purge_behavior is set to "rule" or "none" node manager will.

- Ensure rules set in the node_group code are enforced on the node group, while merging any existing rules and pinned nodes on the node group.
- In the case of conflict between "Nodes must match all rules." and "Nodes may match any rule.". What is set in the PE console takes priority


Currently node_manager provides the ability to accept additional classes and data from users within the PE console by setting the purge_behavior parameter on a node_group basis. I would like to extend the module to include the ability to customise rules and pin nodes on a per node_group basis. 

