### PR TITLE
(CAT-1731) - Update none purge policy to return default rules

### DIFF
--- a/lib/puppet/type/node_group.rb
+++ b/lib/puppet/type/node_group.rb
@@ -37,7 +37,7 @@ Puppet::Type.newtype(:node_group) do
     desc 'Match conditions for this group'
     def should
       case @resource[:purge_behavior]
-      when :rule, :all
+      when :rule, :all, :none
         super
       else
         a = @resource.property(:rule).retrieve || {}


### PR DESCRIPTION
## Summary

Update none purge policy to return default rules.

## Related Issues (if any)
https://perforce.atlassian.net/browse/CAT-1731
https://github.com/WhatsARanjit/puppet-node_manager/pull/68

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)
