### PR TITLE
(CAT-1731) add rules tests

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,0 @@
-{
-  "recommendations": [
-    "puppet.puppet-vscode",
-    "rebornix.Ruby"
-  ]
-}

--- a/lib/puppet/type/node_group.rb
+++ b/lib/puppet/type/node_group.rb
@@ -35,6 +35,8 @@ Puppet::Type.newtype(:node_group) do
   end
   newproperty(:rule, array_matching: :all) do
     desc 'Match conditions for this group'
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     def should
       case @resource[:purge_behavior]
       # only do something special when we are asked to merge, otherwise, fall back to the default
@@ -57,67 +59,55 @@ Puppet::Type.newtype(:node_group) do
         # pinned nodes are in the form ['=', 'name', <hostname>]
         apinned = []
         a_without_pinned = a
-        if (a[0] == 'or')
-          apinned = a.select {|item| (item[0] == '=') && (item[1] == 'name')}
+        if a[0] == 'or'
+          apinned = a.select { |item| (item[0] == '=') && (item[1] == 'name') }
           a_without_pinned = a.select { |item| (item[0] != '=') || (item[1] != 'name') }
         end
         bpinned = []
         b_without_pinned = b
         merged = []
-        if (a == [""])
-           # ensure rules are unique at the top level and remove any empty rule sets
-          return b.uniq.select { |item| (item != ['or'] && item != ['and'] )}
-        elsif (b == [""])
-           # ensure rules are unique at the top level and remove any empty rule sets
-           return a.uniq.select { |item| (item != ['or'] && item != ['and'] )}
-        end
 
-        if (b[0] == 'or')
-          bpinned = b.select {|item| (item[0] == '=') && (item[1] == 'name')}
+        (return b.uniq.select { |item| (item != ['or'] && item != ['and']) } if a == [''])
+        (return a.uniq.select { |item| (item != ['or'] && item != ['and']) } if b == [''])
+
+        if b[0] == 'or'
+          bpinned = b.select { |item| (item[0] == '=') && (item[1] == 'name') }
           b_without_pinned = b.select { |item| (item[0] != '=') || (item[1] != 'name') }
         end
 
-        if (((a[0] == 'and') || (a[0] == 'or')) && a[0] == b[0])
-          # if a and b start with the same 'and' or 'or' clause, we can just combine them
-          if (a[0] == 'or')
-            merged = (['or'] + a_without_pinned.drop(1) + b_without_pinned.drop(1) + apinned + bpinned).uniq
-          else 
-            # must both be 'and' clauses
-            if (apinned.length > 0 || bpinned.length > 0)
-              # we have pinned nodes
-              merged = (['or'] + [a_without_pinned + b_without_pinned.drop(1)] + apinned + bpinned).uniq
-            else 
-              # no pinned nodes and one top level 'and' clause, just combine them.
-              merged = a_without_pinned + b_without_pinned.drop(1)
-            end
-          end
-        else 
-          # first clause of a and b aren't equal 
-          # a first clause is one of and/or/not/operator
-          # b first clause is one of and/or/not/operator
-          # if a starts with `and` and b starts with `or`, create a top level `or` clause, nest a under it and append the rest of b
-          if (a_without_pinned[0] == 'and' && b_without_pinned[0] == 'or')
-            # special case of a only having one subclause
-            if (a_without_pinned.length == 2)
-              merged = (['or'] + a_without_pinned[1] + b_without_pinned.drop(1) + apinned + bpinned)
-            else 
-              merged = (['or'] + [a_without_pinned] + b_without_pinned.drop(1) + apinned + bpinned)
-            end
-          else
-            if (a_without_pinned[0] == 'or')
-              merged = (a_without_pinned + [b_without_pinned] + apinned + bpinned).uniq
-            else 
-              # if b starts with 'or', we want to be sure to drop that.
-              if (b_without_pinned[0] == 'or')
-                merged = (['or'] + [a_without_pinned] + b_without_pinned.drop(1) + apinned + bpinned)
-              else 
-                merged = (['or'] + [a_without_pinned] + [b_without_pinned] + apinned + bpinned)
-              end
-            end
-          end
-        end
+        merged = if ((a[0] == 'and') || (a[0] == 'or')) && a[0] == b[0]
+                   # if a and b start with the same 'and' or 'or' clause, we can just combine them
+                   if a[0] == 'or'
+                     (['or'] + a_without_pinned.drop(1) + b_without_pinned.drop(1) + apinned + bpinned).uniq
+                   elsif apinned.length.positive? || bpinned.length.positive?
+                     # must both be 'and' clauses
+                     (['or'] + [a_without_pinned + b_without_pinned.drop(1)] + apinned + bpinned).uniq
+                   # we have pinned nodes
+                   else
+                     # no pinned nodes and one top level 'and' clause, just combine them.
+                     a_without_pinned + b_without_pinned.drop(1)
+                   end
+                 elsif a_without_pinned[0] == 'and' && b_without_pinned[0] == 'or'
+                   # first clause of a and b aren't equal
+                   # a first clause is one of and/or/not/operator
+                   # b first clause is one of and/or/not/operator
+                   # if a starts with `and` and b starts with `or`, create a top level `or` clause, nest a under it and append the rest of b
+                   if a_without_pinned.length == 2
+                     (['or'] + a_without_pinned[1] + b_without_pinned.drop(1) + apinned + bpinned)
+                   else
+                     (['or'] + [a_without_pinned] + b_without_pinned.drop(1) + apinned + bpinned)
+                   end
+                 # special case of a only having one subclause
+                 elsif a_without_pinned[0] == 'or'
+                   (a_without_pinned + [b_without_pinned] + apinned + bpinned).uniq
+                 elsif b_without_pinned[0] == 'or'
+                   # if b starts with 'or', we want to be sure to drop that.
+                   (['or'] + [a_without_pinned] + b_without_pinned.drop(1) + apinned + bpinned)
+                 else
+                   (['or'] + [a_without_pinned] + [b_without_pinned] + apinned + bpinned)
+                 end
         # ensure rules are unique at the top level and remove any empty rule sets
-        merged.uniq.select { |item| (item != ['or'] && item != ['and'] )}
+        merged.uniq.select { |item| (item != ['or'] && item != ['and']) }
       else
         super
       end
@@ -127,6 +117,8 @@ Puppet::Type.newtype(:node_group) do
       is == should
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
   newproperty(:environment) do
     desc 'Environment for this group'
     defaultto :production

--- a/spec/unit/puppet/type/node_group_spec.rb
+++ b/spec/unit/puppet/type/node_group_spec.rb
@@ -119,6 +119,51 @@ describe Puppet::Type.type(:node_group) do
         'classes::class3' => { 'param1' => 'existing',
                                'param2' => 'existing' } }
     end
+    let(:group_with_rule) do
+      {
+        name: 'test_group',
+        environment: 'test_env',
+        classes: {
+          'classes::class1' => { 'param1' => 'resource',
+                               'param2' => 'resource',
+                               'param3' => 'existing' },
+          'classes::class3' => { 'param1' => 'existing',
+                                'param2' => 'existing' }
+        },
+        rule:
+         ['or',
+          ['~', ['fact', 'fact1'], 'value1'],
+          ['~', ['fact', 'fact2'], 'value2']]
+      }
+    end
+    let(:and_rule) do
+      ['and',
+       ['~', ['fact', 'fact1'], 'value1'],
+       ['~', ['fact', 'fact2'], 'value2']]
+    end
+    let(:or_rule) do
+      ['or',
+       ['~', ['fact', 'fact1'], 'value1'],
+       ['~', ['fact', 'fact2'], 'value2']]
+    end
+
+    it 'matches rule exactly by default' do
+      rsrc = described_class.new(group_with_rule)
+      allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
+      expect(rsrc.property(:rule).should).to eq group_with_rule[:rule]
+    end
+
+    it 'does not update rule when purge behaviour set to :none' do
+      rsrc = described_class.new(group_with_rule.merge(purge_behavior: 'none'))
+      allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
+      expect(rsrc.property(:rule).should).to eq and_rule
+    end
+
+    it 'updates rule when purge behaviour set to :rule' do
+      rsrc = described_class.new(group_with_rule.merge(purge_behavior: 'rule'))
+      allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
+      expect(rsrc.property(:rule).should).to eq group_with_rule[:rule]
+    end
 
     it 'matches classes and data exactly by default' do
       rsrc = described_class.new(resource_hash)

--- a/spec/unit/puppet/type/node_group_spec.rb
+++ b/spec/unit/puppet/type/node_group_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+# rubocop:disable Metrics/BlockLength
 describe Puppet::Type.type(:node_group) do
   it 'allows agent-specified environment' do
     expect {
@@ -73,8 +74,6 @@ describe Puppet::Type.type(:node_group) do
   end
 
   describe 'purge_behavior' do
-   
-
     let(:and_rule) do
       ['and',
        ['~', ['fact', 'fact1'], 'value1'],
@@ -105,14 +104,14 @@ describe Puppet::Type.type(:node_group) do
         }
       end
       let(:group_with_merged_and_rule) do
-        ["or", 
-          ["and", 
-            ["~", ["fact", "fact1"], "value1"], 
-            ["~", ["fact", "fact2"], "value2"]], 
-          ["~", ["fact", "fact1"], "value1"], 
-          ["~", ["fact", "fact2"], "value2"]]
+        ['or',
+         ['and',
+          ['~', ['fact', 'fact1'], 'value1'],
+          ['~', ['fact', 'fact2'], 'value2']],
+         ['~', ['fact', 'fact1'], 'value1'],
+         ['~', ['fact', 'fact2'], 'value2']]
       end
-  
+
       it 'replaces by default' do
         rsrc = described_class.new(group_with_rule)
         # this is simulated data from the classifier service
@@ -163,20 +162,20 @@ describe Puppet::Type.type(:node_group) do
       # to the end
       # also the merging optimizes the pinned nodes to remove redundants.
       let(:merged_pinned_nodes_and_rule) do
-        ["or", 
-          ["and", 
-            ["~", ["fact", "fact1"], "value1"], 
-            ["~", ["fact", "fact2"], "value2"]], 
-          ["=", "name", "value1"], 
-          ["=", "name", "value2"]]
+        ['or',
+         ['and',
+          ['~', ['fact', 'fact1'], 'value1'],
+          ['~', ['fact', 'fact2'], 'value2']],
+         ['=', 'name', 'value1'],
+         ['=', 'name', 'value2']]
       end
 
       let(:merged_pinned_nodes_or_rule) do
-        ["or", 
-          ["~", ["fact", "fact1"], "value1"], 
-          ["~", ["fact", "fact2"], "value2"], 
-          ["=", "name", "value1"], 
-          ["=", "name", "value2"]]
+        ['or',
+         ['~', ['fact', 'fact1'], 'value1'],
+         ['~', ['fact', 'fact2'], 'value2'],
+         ['=', 'name', 'value1'],
+         ['=', 'name', 'value2']]
       end
 
       it 'matches rule exactly by default' do
@@ -199,9 +198,9 @@ describe Puppet::Type.type(:node_group) do
 
       it 'merges pinned node correctly when purge behaviour set to :none' do
         rsrc = described_class.new(group_with_pinned_nodes.merge(purge_behavior: 'none'))
-        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(["=", "name", "value2"])
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(['=', 'name', 'value2'])
         # redundant node pinning is removed
-        expect(rsrc.property(:rule).should).to eq ["or", ["=", "name", "value2"], ["=", "name", "value1"]]
+        expect(rsrc.property(:rule).should).to eq ['or', ['=', 'name', 'value2'], ['=', 'name', 'value1']]
       end
 
       it 'replaces rule when purge behaviour set to :all' do
@@ -215,7 +214,6 @@ describe Puppet::Type.type(:node_group) do
         allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
         expect(rsrc.property(:rule).should).to eq group_with_pinned_nodes[:rule]
       end
-
     end
 
     describe 'group with top-level and clause' do
@@ -236,17 +234,17 @@ describe Puppet::Type.type(:node_group) do
       end
 
       let(:rule_combined_and_clauses) do
-        ["and",
-          ["~", ["fact", "fact1"], "value1"],
-          ["~", ["fact", "fact2"], "value2"],
-          ["~", ["fact", "pe_server_version"], ".+"]]
+        ['and',
+         ['~', ['fact', 'fact1'], 'value1'],
+         ['~', ['fact', 'fact2'], 'value2'],
+         ['~', ['fact', 'pe_server_version'], '.+']]
       end
 
       let(:rule_combined_or_clauses) do
-        ["or",
-          ["~", ["fact", "fact1"], "value1"],
-          ["~", ["fact", "fact2"], "value2"],
-          ["and", ["~", ["fact", "pe_server_version"], ".+"]]]
+        ['or',
+         ['~', ['fact', 'fact1'], 'value1'],
+         ['~', ['fact', 'fact2'], 'value2'],
+         ['and', ['~', ['fact', 'pe_server_version'], '.+']]]
       end
 
       it 'replaces rule exactly by default' do
@@ -269,9 +267,9 @@ describe Puppet::Type.type(:node_group) do
 
       it 'merges pinned node correctly when purge behaviour set to :none' do
         rsrc = described_class.new(group_with_and_clause.merge(purge_behavior: 'none'))
-        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(["=", "name", "value2"])
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(['=', 'name', 'value2'])
         # redundant node pinning is removed
-        expect(rsrc.property(:rule).should).to eq ["or", ["=", "name", "value2"], ["and", ["~", ["fact", "pe_server_version"], ".+"]]]
+        expect(rsrc.property(:rule).should).to eq ['or', ['=', 'name', 'value2'], ['and', ['~', ['fact', 'pe_server_version'], '.+']]]
       end
 
       it 'replaces rule when purge behaviour set to :all' do
@@ -285,7 +283,6 @@ describe Puppet::Type.type(:node_group) do
         allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
         expect(rsrc.property(:rule).should).to eq group_with_and_clause[:rule]
       end
-
     end
 
     describe 'resource hash' do
@@ -305,7 +302,7 @@ describe Puppet::Type.type(:node_group) do
           },
         }
       end
-  
+
       let(:existing_data) do
         { 'data::class1' => { 'param1' => 'existing',
                               'param3' => 'existing' },
@@ -321,7 +318,7 @@ describe Puppet::Type.type(:node_group) do
           'data::class3' => { 'param1' => 'existing',
                               'param2' => 'existing' } }
       end
-  
+
       let(:existing_classes) do
         { 'classes::class1' => { 'param1' => 'existing',
                                  'param3' => 'existing' },
@@ -335,7 +332,7 @@ describe Puppet::Type.type(:node_group) do
           'classes::class3' => { 'param1' => 'existing',
                                  'param2' => 'existing' } }
       end
-  
+
       it 'matches classes and data exactly by default' do
         rsrc = described_class.new(resource_hash)
         allow(rsrc.property(:data)).to receive(:retrieve).and_return(existing_data)
@@ -368,7 +365,6 @@ describe Puppet::Type.type(:node_group) do
         expect(rsrc.property(:classes).should).to eq(resource_hash[:classes])
       end
     end
-
   end
 
   describe '.insync? for data, classes' do
@@ -414,3 +410,4 @@ describe Puppet::Type.type(:node_group) do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/unit/puppet/type/node_group_spec.rb
+++ b/spec/unit/puppet/type/node_group_spec.rb
@@ -73,69 +73,8 @@ describe Puppet::Type.type(:node_group) do
   end
 
   describe 'purge_behavior' do
-    let(:resource_hash) do
-      {
-        name: 'test_group',
-        environment: 'test_env',
-        data: {
-          'data::class1' => { 'param1' => 'resource',
-                              'param2' => 'resource' },
-          'data::class2' => { 'param1' => 'resource',
-                              'param2' => 'resource' },
-        },
-        classes: {
-          'classes::class1' => { 'param1' => 'resource',
-                                 'param2' => 'resource' },
-        },
-      }
-    end
+   
 
-    let(:existing_data) do
-      { 'data::class1' => { 'param1' => 'existing',
-                            'param3' => 'existing' },
-        'data::class3' => { 'param1' => 'existing',
-                            'param2' => 'existing' } }
-    end
-    let(:merged_data) do
-      { 'data::class1' => { 'param1' => 'resource',
-                            'param2' => 'resource',
-                            'param3' => 'existing' },
-        'data::class2' => { 'param1' => 'resource',
-                            'param2' => 'resource' },
-        'data::class3' => { 'param1' => 'existing',
-                            'param2' => 'existing' } }
-    end
-
-    let(:existing_classes) do
-      { 'classes::class1' => { 'param1' => 'existing',
-                               'param3' => 'existing' },
-        'classes::class3' => { 'param1' => 'existing',
-                               'param2' => 'existing' } }
-    end
-    let(:merged_classes) do
-      { 'classes::class1' => { 'param1' => 'resource',
-                               'param2' => 'resource',
-                               'param3' => 'existing' },
-        'classes::class3' => { 'param1' => 'existing',
-                               'param2' => 'existing' } }
-    end
-    let(:group_with_rule) do
-      {
-        name: 'test_group',
-        environment: 'test_env',
-        classes: {
-          'classes::class1' => { 'param1' => 'resource',
-                               'param2' => 'resource',
-                               'param3' => 'existing' },
-          'classes::class3' => { 'param1' => 'existing',
-                                'param2' => 'existing' }
-        },
-        rule:
-         ['or',
-          ['~', ['fact', 'fact1'], 'value1'],
-          ['~', ['fact', 'fact2'], 'value2']]
-      }
-    end
     let(:and_rule) do
       ['and',
        ['~', ['fact', 'fact1'], 'value1'],
@@ -147,55 +86,289 @@ describe Puppet::Type.type(:node_group) do
        ['~', ['fact', 'fact2'], 'value2']]
     end
 
-    it 'matches rule exactly by default' do
-      rsrc = described_class.new(group_with_rule)
-      allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
-      expect(rsrc.property(:rule).should).to eq group_with_rule[:rule]
+    describe 'group_with_rule' do
+      let(:group_with_rule) do
+        {
+          name: 'test_group',
+          environment: 'test_env',
+          classes: {
+            'classes::class1' => { 'param1' => 'resource',
+                                 'param2' => 'resource',
+                                 'param3' => 'existing' },
+            'classes::class3' => { 'param1' => 'existing',
+                                  'param2' => 'existing' }
+          },
+          rule:
+           ['or',
+            ['~', ['fact', 'fact1'], 'value1'],
+            ['~', ['fact', 'fact2'], 'value2']]
+        }
+      end
+      let(:group_with_merged_and_rule) do
+        ["or", 
+          ["and", 
+            ["~", ["fact", "fact1"], "value1"], 
+            ["~", ["fact", "fact2"], "value2"]], 
+          ["~", ["fact", "fact1"], "value1"], 
+          ["~", ["fact", "fact2"], "value2"]]
+      end
+  
+      it 'replaces by default' do
+        rsrc = described_class.new(group_with_rule)
+        # this is simulated data from the classifier service
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
+        expect(rsrc.property(:rule).should).to eq group_with_rule[:rule]
+      end
+
+      it 'merges when purge behaviour set to :none' do
+        rsrc = described_class.new(group_with_rule.merge(purge_behavior: 'none'))
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
+        expect(rsrc.property(:rule).should).to eq group_with_merged_and_rule
+      end
+
+      it 'replaces rule when purge behaviour set to :all' do
+        rsrc = described_class.new(group_with_rule.merge(purge_behavior: 'all'))
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
+        expect(rsrc.property(:rule).should).to eq group_with_rule[:rule]
+      end
+
+      it 'updates rule when purge behaviour set to :rule' do
+        rsrc = described_class.new(group_with_rule.merge(purge_behavior: 'rule'))
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
+        expect(rsrc.property(:rule).should).to eq group_with_rule[:rule]
+      end
     end
 
-    it 'does not update rule when purge behaviour set to :none' do
-      rsrc = described_class.new(group_with_rule.merge(purge_behavior: 'none'))
-      allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
-      expect(rsrc.property(:rule).should).to eq and_rule
+    describe 'group with pinned nodes' do
+      let(:group_with_pinned_nodes) do
+        {
+          name: 'test_group',
+          environment: 'test_env',
+          classes: {
+            'classes::class1' => { 'param1' => 'resource',
+                                 'param2' => 'resource',
+                                 'param3' => 'existing' },
+            'classes::class3' => { 'param1' => 'existing',
+                                  'param2' => 'existing' }
+          },
+          rule:
+           ['or',
+            ['=', 'name', 'value1'],
+            ['=', 'name', 'value2'],
+            ['=', 'name', 'value2']]
+        }
+      end
+
+      # when merging the pinned nodes and the and rule, the top level "or" clause should be maintained, and the pinned nodes added
+      # to the end
+      # also the merging optimizes the pinned nodes to remove redundants.
+      let(:merged_pinned_nodes_and_rule) do
+        ["or", 
+          ["and", 
+            ["~", ["fact", "fact1"], "value1"], 
+            ["~", ["fact", "fact2"], "value2"]], 
+          ["=", "name", "value1"], 
+          ["=", "name", "value2"]]
+      end
+
+      let(:merged_pinned_nodes_or_rule) do
+        ["or", 
+          ["~", ["fact", "fact1"], "value1"], 
+          ["~", ["fact", "fact2"], "value2"], 
+          ["=", "name", "value1"], 
+          ["=", "name", "value2"]]
+      end
+
+      it 'matches rule exactly by default' do
+        rsrc = described_class.new(group_with_pinned_nodes)
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
+        expect(rsrc.property(:rule).should).to eq group_with_pinned_nodes[:rule]
+      end
+
+      it 'merges and rule correctly when purge behaviour set to :none' do
+        rsrc = described_class.new(group_with_pinned_nodes.merge(purge_behavior: 'none'))
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
+        expect(rsrc.property(:rule).should).to eq merged_pinned_nodes_and_rule
+      end
+
+      it 'merges or rule correctly when purge behaviour set to :none' do
+        rsrc = described_class.new(group_with_pinned_nodes.merge(purge_behavior: 'none'))
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(or_rule)
+        expect(rsrc.property(:rule).should).to eq merged_pinned_nodes_or_rule
+      end
+
+      it 'merges pinned node correctly when purge behaviour set to :none' do
+        rsrc = described_class.new(group_with_pinned_nodes.merge(purge_behavior: 'none'))
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(["=", "name", "value2"])
+        # redundant node pinning is removed
+        expect(rsrc.property(:rule).should).to eq ["or", ["=", "name", "value2"], ["=", "name", "value1"]]
+      end
+
+      it 'replaces rule when purge behaviour set to :all' do
+        rsrc = described_class.new(group_with_pinned_nodes.merge(purge_behavior: 'all'))
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
+        expect(rsrc.property(:rule).should).to eq group_with_pinned_nodes[:rule]
+      end
+
+      it 'replaces rule when purge behaviour set to :rule' do
+        rsrc = described_class.new(group_with_pinned_nodes.merge(purge_behavior: 'rule'))
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
+        expect(rsrc.property(:rule).should).to eq group_with_pinned_nodes[:rule]
+      end
+
     end
 
-    it 'updates rule when purge behaviour set to :rule' do
-      rsrc = described_class.new(group_with_rule.merge(purge_behavior: 'rule'))
-      allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
-      expect(rsrc.property(:rule).should).to eq group_with_rule[:rule]
+    describe 'group with top-level and clause' do
+      let(:group_with_and_clause) do
+        {
+          name: 'test_group',
+          environment: 'test_env',
+          classes: {
+            'classes::class1' => { 'param1' => 'resource',
+                                 'param2' => 'resource',
+                                 'param3' => 'existing' },
+            'classes::class3' => { 'param1' => 'existing',
+                                  'param2' => 'existing' }
+          },
+          rule:
+           ['and', ['~', ['fact', 'pe_server_version'], '.+']]
+        }
+      end
+
+      let(:rule_combined_and_clauses) do
+        ["and",
+          ["~", ["fact", "fact1"], "value1"],
+          ["~", ["fact", "fact2"], "value2"],
+          ["~", ["fact", "pe_server_version"], ".+"]]
+      end
+
+      let(:rule_combined_or_clauses) do
+        ["or",
+          ["~", ["fact", "fact1"], "value1"],
+          ["~", ["fact", "fact2"], "value2"],
+          ["and", ["~", ["fact", "pe_server_version"], ".+"]]]
+      end
+
+      it 'replaces rule exactly by default' do
+        rsrc = described_class.new(group_with_and_clause)
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
+        expect(rsrc.property(:rule).should).to eq group_with_and_clause[:rule]
+      end
+
+      it 'merges and rule correctly when purge behaviour set to :none' do
+        rsrc = described_class.new(group_with_and_clause.merge(purge_behavior: 'none'))
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
+        expect(rsrc.property(:rule).should).to eq rule_combined_and_clauses
+      end
+
+      it 'merges or rule correctly when purge behaviour set to :none' do
+        rsrc = described_class.new(group_with_and_clause.merge(purge_behavior: 'none'))
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(or_rule)
+        expect(rsrc.property(:rule).should).to eq rule_combined_or_clauses
+      end
+
+      it 'merges pinned node correctly when purge behaviour set to :none' do
+        rsrc = described_class.new(group_with_and_clause.merge(purge_behavior: 'none'))
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(["=", "name", "value2"])
+        # redundant node pinning is removed
+        expect(rsrc.property(:rule).should).to eq ["or", ["=", "name", "value2"], ["and", ["~", ["fact", "pe_server_version"], ".+"]]]
+      end
+
+      it 'replaces rule when purge behaviour set to :all' do
+        rsrc = described_class.new(group_with_and_clause.merge(purge_behavior: 'all'))
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
+        expect(rsrc.property(:rule).should).to eq group_with_and_clause[:rule]
+      end
+
+      it 'replaces rule when purge behaviour set to :rule' do
+        rsrc = described_class.new(group_with_and_clause.merge(purge_behavior: 'rule'))
+        allow(rsrc.property(:rule)).to receive(:retrieve).and_return(and_rule)
+        expect(rsrc.property(:rule).should).to eq group_with_and_clause[:rule]
+      end
+
     end
 
-    it 'matches classes and data exactly by default' do
-      rsrc = described_class.new(resource_hash)
-      allow(rsrc.property(:data)).to receive(:retrieve).and_return(existing_data)
-      allow(rsrc.property(:classes)).to receive(:retrieve).and_return(existing_classes)
-      expect(rsrc.property(:data).should).to eq resource_hash[:data]
-      expect(rsrc.property(:classes).should).to eq resource_hash[:classes]
+    describe 'resource hash' do
+      let(:resource_hash) do
+        {
+          name: 'test_group',
+          environment: 'test_env',
+          data: {
+            'data::class1' => { 'param1' => 'resource',
+                                'param2' => 'resource' },
+            'data::class2' => { 'param1' => 'resource',
+                                'param2' => 'resource' },
+          },
+          classes: {
+            'classes::class1' => { 'param1' => 'resource',
+                                   'param2' => 'resource' },
+          },
+        }
+      end
+  
+      let(:existing_data) do
+        { 'data::class1' => { 'param1' => 'existing',
+                              'param3' => 'existing' },
+          'data::class3' => { 'param1' => 'existing',
+                              'param2' => 'existing' } }
+      end
+      let(:merged_data) do
+        { 'data::class1' => { 'param1' => 'resource',
+                              'param2' => 'resource',
+                              'param3' => 'existing' },
+          'data::class2' => { 'param1' => 'resource',
+                              'param2' => 'resource' },
+          'data::class3' => { 'param1' => 'existing',
+                              'param2' => 'existing' } }
+      end
+  
+      let(:existing_classes) do
+        { 'classes::class1' => { 'param1' => 'existing',
+                                 'param3' => 'existing' },
+          'classes::class3' => { 'param1' => 'existing',
+                                 'param2' => 'existing' } }
+      end
+      let(:merged_classes) do
+        { 'classes::class1' => { 'param1' => 'resource',
+                                 'param2' => 'resource',
+                                 'param3' => 'existing' },
+          'classes::class3' => { 'param1' => 'existing',
+                                 'param2' => 'existing' } }
+      end
+  
+      it 'matches classes and data exactly by default' do
+        rsrc = described_class.new(resource_hash)
+        allow(rsrc.property(:data)).to receive(:retrieve).and_return(existing_data)
+        allow(rsrc.property(:classes)).to receive(:retrieve).and_return(existing_classes)
+        expect(rsrc.property(:data).should).to eq resource_hash[:data]
+        expect(rsrc.property(:classes).should).to eq resource_hash[:classes]
+      end
+
+      it 'merges in classes and data when set to :none' do
+        rsrc = described_class.new(resource_hash.merge(purge_behavior: 'none'))
+        allow(rsrc.property(:data)).to receive(:retrieve).and_return(existing_data)
+        allow(rsrc.property(:classes)).to receive(:retrieve).and_return(existing_classes)
+        expect(rsrc.property(:data).should).to eq(merged_data)
+        expect(rsrc.property(:classes).should).to eq(merged_classes)
+      end
+
+      it 'merges in classes and match data exactly when set to :data' do
+        rsrc = described_class.new(resource_hash.merge(purge_behavior: 'data'))
+        allow(rsrc.property(:data)).to receive(:retrieve).and_return(existing_data)
+        allow(rsrc.property(:classes)).to receive(:retrieve).and_return(existing_classes)
+        expect(rsrc.property(:data).should).to eq(resource_hash[:data])
+        expect(rsrc.property(:classes).should).to eq(merged_classes)
+      end
+
+      it 'merges in data and match classes exactly when set to :classes' do
+        rsrc = described_class.new(resource_hash.merge(purge_behavior: 'classes'))
+        allow(rsrc.property(:data)).to receive(:retrieve).and_return(existing_data)
+        allow(rsrc.property(:classes)).to receive(:retrieve).and_return(existing_classes)
+        expect(rsrc.property(:data).should).to eq(merged_data)
+        expect(rsrc.property(:classes).should).to eq(resource_hash[:classes])
+      end
     end
 
-    it 'merges in classes and data when set to :none' do
-      rsrc = described_class.new(resource_hash.merge(purge_behavior: 'none'))
-      allow(rsrc.property(:data)).to receive(:retrieve).and_return(existing_data)
-      allow(rsrc.property(:classes)).to receive(:retrieve).and_return(existing_classes)
-      expect(rsrc.property(:data).should).to eq(merged_data)
-      expect(rsrc.property(:classes).should).to eq(merged_classes)
-    end
-
-    it 'merges in classes and match data exactly when set to :data' do
-      rsrc = described_class.new(resource_hash.merge(purge_behavior: 'data'))
-      allow(rsrc.property(:data)).to receive(:retrieve).and_return(existing_data)
-      allow(rsrc.property(:classes)).to receive(:retrieve).and_return(existing_classes)
-      expect(rsrc.property(:data).should).to eq(resource_hash[:data])
-      expect(rsrc.property(:classes).should).to eq(merged_classes)
-    end
-
-    it 'merges in data and match classes exactly when set to :classes' do
-      rsrc = described_class.new(resource_hash.merge(purge_behavior: 'classes'))
-      allow(rsrc.property(:data)).to receive(:retrieve).and_return(existing_data)
-      allow(rsrc.property(:classes)).to receive(:retrieve).and_return(existing_classes)
-      expect(rsrc.property(:data).should).to eq(merged_data)
-      expect(rsrc.property(:classes).should).to eq(resource_hash[:classes])
-    end
   end
 
   describe '.insync? for data, classes' do


### PR DESCRIPTION
## Summary
Within the Puppet Enterprise UI console the concept of pinned nodes
allows more complex rules to be expressed while including pinned nodes.

Pinned nodes are formed by having a top level "or" clause, with
expressions in the form

`['=', 'name', 'hostname']`

Prior to this change, the code would not properly maintain pinned nodes,
nor correctly handle merging expressions like:

```
['and',
  ['~',
    ['fact', 'pe_server_version'],
    '.+']]
```

with
```
['or', ['~',
    ['trusted', 'extensions', '1.3.6.1.4.1.34380.1.1.9812'],
    '^puppet/']]
```

Incorrectly combining them into an `and` clause when logically they should be an "or" clause.

With this change, pinned nodes are separated our from the other rules
and then recombined later (if they are present) with a top-level "or" clause.

Test are added to demonstrate the behaviors.

## Additional Context
Add any additional context about the problem here. 
- [X] Root cause and the steps to reproduce. (If applicable)
- [X] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [X] 🟢 Spec tests.
